### PR TITLE
add build support fo aarch64 & riscv64 

### DIFF
--- a/.github/actions/publish-release/action.yaml
+++ b/.github/actions/publish-release/action.yaml
@@ -36,7 +36,7 @@ runs:
   steps:
     # Install go with specific version
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }} # same version than the one in the go.mod or in the .go-version
      # Register to ghcr.io container Registry
@@ -48,10 +48,10 @@ runs:
         password: ${{ inputs.registry_password }} 
     # Install ko to publish container images
     - name: Set up Ko
-      uses: ko-build/setup-ko@v0.7
+      uses: ko-build/setup-ko@v0.9
     # Install cosign to sign artfacts with goreleaser 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.5.0
+      uses: sigstore/cosign-installer@v3.10.0
     # Get LDFLAGS with a makefile command
     - shell: bash
       name: Get LDFLAGS

--- a/.github/actions/publish-release/action.yaml
+++ b/.github/actions/publish-release/action.yaml
@@ -1,6 +1,6 @@
-name: Publish release
+name: Build Go & publish release
 
-description: Publish release, container image, SBOMS, signs artifacts. 
+description: Build Go app, publish release, container image, SBOMS, signs artifacts. 
 
 inputs:
   go-version:
@@ -61,10 +61,27 @@ runs:
         echo "ldflags= $(make get-ldflags)" >> "$GITHUB_OUTPUT"
     # Install other dependencies like scanners and go librairies
     - shell: bash 
-      name : Install dependencies
+      name : Install software composition analysis tools
       run : |
         curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
         curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.49.1
+    
+    - shell: bash
+      name: Install cross-compilers for aarch64 and riscv64
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          gcc-aarch64-linux-gnu \
+          gcc-riscv64-linux-gnu \
+          libc6-dev-arm64-cross \
+          libc6-dev-riscv64-cross
+
+    - shell: bash
+      name: Verify cross toolchains for aarch64 and riscv64
+      run: |
+        aarch64-linux-gnu-gcc --version
+        riscv64-linux-gnu-gcc --version
+    
     # Run command goreleaser release based on .goreleaser.yml
     # LDFLAGS are passed thanks to the steps.job_id.outputs.variable_name variable
     - name: Run GoReleaser

--- a/.github/actions/publish-release/action.yaml
+++ b/.github/actions/publish-release/action.yaml
@@ -34,11 +34,12 @@ outputs:
 runs: 
   using: composite
   steps:
-    # Install go with specific version
+    # Install go with specific version for go build
+    - uses: actions/checkout@v5
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ inputs.go-version }} # same version than the one in the go.mod or in the .go-version
+        go-version-file: ${{ github.workspace }}/go.mod # same version than the one in the go.mod
      # Register to ghcr.io container Registry
     - name: 'Login to GitHub Container Registry'
       uses: docker/login-action@v3

--- a/.github/actions/verify-attestations/action.yaml
+++ b/.github/actions/verify-attestations/action.yaml
@@ -25,18 +25,18 @@ runs:
   steps:
     # Install go with specific version
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }} # same version than the one in the go.mod or in the .go-version
 
     - shell: bash 
       name : Install dependencies
       run : |
-        go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.5.1
+        go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.7.1
     - shell: bash 
       name: verify image provenance
       id: image-provenance   
       run: |
           slsa-verifier verify-image ${{ inputs.image }} \
           --source-uri  github.com/${{github.repository}} \
-          --builder-id https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v1.10.0
+          --builder-id https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v2.1.0

--- a/.github/actions/verify-attestations/action.yaml
+++ b/.github/actions/verify-attestations/action.yaml
@@ -23,11 +23,11 @@ inputs:
 runs: 
   using: composite
   steps:
-    # Install go with specific version
+    # Install go latest stable
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ inputs.go-version }} # same version than the one in the go.mod or in the .go-version
+        go-version: 'stable'
 
     - shell: bash 
       name : Install dependencies

--- a/.github/workflows/Goreleaser.yaml
+++ b/.github/workflows/Goreleaser.yaml
@@ -22,7 +22,7 @@ jobs:
         digest: ${{ steps.publish-artifacts.outputs.digest }}
       steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
           with:
                 fetch-depth: 0      
         - name: Publish Artifacts
@@ -43,7 +43,7 @@ jobs:
         actions: read # To read the workflow path.
         id-token: write # To sign the provenance.
         contents: write # To add assets to a release.
-      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
       with:
         base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
         upload-assets: true 
@@ -54,7 +54,7 @@ jobs:
         actions: read
         id-token: write
         packages: write
-      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
+      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
       with:
         image: ${{ needs.goreleaser.outputs.image }}
         digest: ${{ needs.goreleaser.outputs.digest }}
@@ -72,7 +72,7 @@ jobs:
         packages: write
       steps:
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
             with:
                   fetch-depth: 0      
           - name: Verify provenance attestations

--- a/.github/workflows/Goreleaser.yaml
+++ b/.github/workflows/Goreleaser.yaml
@@ -29,7 +29,7 @@ jobs:
           id : publish-artifacts
           uses: ./.github/actions/publish-release
           with:
-            go-version: 1.23.6
+            go-version: 1.24.5
             github_token : ${{ secrets.GITHUB_TOKEN }}
             registry: ghcr.io
             registry_username: ${{ github.actor }}
@@ -79,6 +79,6 @@ jobs:
             id : slsa-verifier
             uses: ./.github/actions/verify-attestations
             with:
-              go-version: 1.23.6
+              go-version: 1.24.5
               github_token : ${{ secrets.GITHUB_TOKEN }}
               image: ${{needs.goreleaser.outputs.image}}@${{needs.goreleaser.outputs.digest}} 

--- a/.github/workflows/Goreleaser.yaml
+++ b/.github/workflows/Goreleaser.yaml
@@ -9,7 +9,6 @@ on:
       - "*"
       
 jobs:
-
     goreleaser:
       runs-on: ubuntu-latest
       env: 
@@ -29,7 +28,6 @@ jobs:
           id : publish-artifacts
           uses: ./.github/actions/publish-release
           with:
-            go-version: 1.24.5
             github_token : ${{ secrets.GITHUB_TOKEN }}
             registry: ghcr.io
             registry_username: ${{ github.actor }}
@@ -74,11 +72,10 @@ jobs:
           - name: Checkout
             uses: actions/checkout@v5
             with:
-                  fetch-depth: 0      
+              fetch-depth: 0      
           - name: Verify provenance attestations
             id : slsa-verifier
             uses: ./.github/actions/verify-attestations
             with:
-              go-version: 1.24.5
               github_token : ${{ secrets.GITHUB_TOKEN }}
               image: ${{needs.goreleaser.outputs.image}}@${{needs.goreleaser.outputs.digest}} 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,8 +34,18 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
+      - riscv64
     ldflags:
       - "{{ .Env.LDFLAGS }}"
+    env:
+      - >-
+        {{- if eq .Os "linux" }}
+          {{- if eq .Arch "amd64"}}CC=gcc{{- end }}
+          {{- if eq .Arch "arm64"}}CC=aarch64-linux-gnu-gcc{{- end }}
+          {{- if eq .Arch "riscv64"}}CC=riscv64-linux-gnu-gcc{{- end }}
+        {{- end }}
+
 
 # Use ko-build to publish container image to a specific registry
 # It is possible to define platforms

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
     binary: '{{ .ProjectName }}_linux_{{ .Arch }}_{{ .Version }}'
     no_unique_dist_dir: true
     main: ./cmd/{{ .ProjectName }}/main.go
-    
+
     mod_timestamp: '{{ .CommitTimestamp }}'
     goos:
       - linux
@@ -50,7 +50,7 @@ builds:
 # Use ko-build to publish container image to a specific registry
 # It is possible to define platforms
 kos:
-  - repositories: 
+  - repositories:
       - ghcr.io/{{ .Env.GITHUB_REPOSITORY }}
     tags:
       - "{{.Tag}}"
@@ -78,9 +78,9 @@ nfpms:
     homepage: https://github.com/ThalesGroup/k8s-kms-plugin
     maintainer: Thales Open Source <oss@thalesgroup.com>
     description: |-
-      gRPC service that leverages a remote or local HSM/TPM to encrypt Kubernetes data at-rest with KMS v2. 
+      gRPC service that leverages a remote or local HSM/TPM to encrypt Kubernetes data at-rest with KMS v2.
     ids:
-      - k8s-kms-plugin # need to use the same id that the build id 
+      - k8s-kms-plugin # need to use the same id that the build id
     formats:
         - apk
         - deb
@@ -111,17 +111,16 @@ archives:
   - id: binary-uncompressed
     formats:
       - binary
-    name_template: "{{ .Binary }}" 
+    name_template: "{{ .Binary }}"
     allow_different_binary_count: true
   - id: binary-compressed-archives
     formats:
       - zip
       - tar.gz
-    name_template: "{{ .Binary }}" 
+    name_template: "{{ .Binary }}"
     allow_different_binary_count: true
 # create metadata file
 metadata:
-  
   mod_timestamp: "{{ .CommitTimestamp }}"
 
 
@@ -168,7 +167,7 @@ signs:
       - "--output-certificate=${certificate}"
       - "--output-signature=${signature}"
       - "-y"
-      - "${artifact}"   
+      - "${artifact}"
     artifacts: binary
     output: true
   - id : checksum-keyless
@@ -182,7 +181,7 @@ signs:
       - "--output-certificate=${certificate}"
       - "--output-signature=${signature}"
       - "-y"
-      - "${artifact}"   
+      - "${artifact}"
     artifacts: checksum
     output: true
   - id : package-keyless
@@ -196,7 +195,7 @@ signs:
       - "--output-certificate=${certificate}"
       - "--output-signature=${signature}"
       - "-y"
-      - "${artifact}" 
+      - "${artifact}"
     artifacts: package
     output: true
   - id : 'sbom-keyless'
@@ -213,9 +212,9 @@ signs:
       - "${artifact}"
     artifacts: sbom
     output: true
-  
 
-# Create a release 
+
+# Create a release
 release:
   # draft: true # Used to publish a draft on github
   make_latest: true

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,15 @@
 # https://opensource.org/licenses/MIT.
 .PHONY: all lint build coverage dev gen
 
-all: build
+all: build-linux-amd64 build-linux-arm64 build-linux-riscv64
 
+#==============================================================================#
 # Project name
 PROJECT_NAME := k8s-kms-plugin
 GO_MODULE_NAME := "github.com/ThalesGroup/$(PROJECT_NAME)"
+BINARY_NAME = $(PROJECT_NAME)
 
+#==============================================================================#
 # Useful variables for build metadata
 VERSION ?= $(shell git describe --tags --always --dirty)
 # equivalent command to test git dirty status in bash terminal: [[ -n "$(git status --porcelain)" ]] && echo "true" || echo "false"
@@ -23,27 +26,36 @@ GO_VERSION ?= $(shell go version)
 BUILD_PLATFORM  ?= $(shell uname -m)
 BUILD_DATE ?= $(shell date -u --iso-8601=seconds)
 
-LDFLAGS = "-X '$(GO_MODULE_NAME)/pkg/version.RawGitDescribe=$(VERSION)' \
+#==============================================================================#
+# Go Flags
+GIT_INFO_LDFLAGS = -X '$(GO_MODULE_NAME)/pkg/version.RawGitDescribe=$(VERSION)' \
 	-X '$(GO_MODULE_NAME)/pkg/version.GitCommitIdLong=$(COMMIT_LONG)' \
 	-X '$(GO_MODULE_NAME)/pkg/version.GitCommitIdShort=$(COMMIT_SHORT)' \
 	-X '$(GO_MODULE_NAME)/pkg/version.GoVersion=$(GO_VERSION)' \
 	-X '$(GO_MODULE_NAME)/pkg/version.BuildPlatform=$(BUILD_PLATFORM)' \
 	-X '$(GO_MODULE_NAME)/pkg/version.BuildDate=$(BUILD_DATE)' \
 	-X '$(GO_MODULE_NAME)/pkg/version.GitCommitTimestamp=$(COMMIT_TIMESTAMP)' \
-	-X '$(GO_MODULE_NAME)/pkg/version.GitDirtyStr=$(IS_GIT_DIRTY)'"
+	-X '$(GO_MODULE_NAME)/pkg/version.GitDirtyStr=$(IS_GIT_DIRTY)'
 
-GO_LDFLAGS = -ldflags=$(LDFLAGS)
-BINARY_NAME = $(PROJECT_NAME)
-
+#==============================================================================#
 # For dev
 SECRET_NAME=gcr-json-key
 P11_TOKEN=ajak
 P11_PIN=password
 ## Pipeline
 
-# Go parameters
+#==============================================================================#
+# Go build parameters
 CGO_ENABLED := "1"
+# Output directories
+DIST_DIR := dist
+# Cross-compiler environment variables when compiling for aarch64 from x86
+LINUX_AMD64_GCC := gcc
+LINUX_ARM64_GCC := aarch64-linux-gnu-gcc
+LINUX_RISCV64_GCC := riscv64-linux-gnu-gcc
 
+#==============================================================================#
+# lint & SAST
 lint:
 		@golangci-lint run
 coverage:
@@ -51,7 +63,9 @@ coverage:
 		go test -race -v -coverprofile build/coverage.out ./pkg/...
 		go tool cover -html=build/coverage.out -o build/coverage.html
 
-## Dev
+#==============================================================================#
+# gRPC & openapi
+# TODO: consider archiving this
 gen: gen-grpc gen-openapi
 gen-grpc:
 		@prototool all || true
@@ -61,14 +75,44 @@ gen-grpc:
 gen-openapi:
 		@swagger generate server --quiet -m pkg/est/models -s pkg/est/restapi -f apis/kms/v1/est.yaml
 		@swagger generate client --quiet --existing-models=pkg/est/models -c pkg/est/client -f apis/kms/v1/est.yaml
-build:
+
+#==============================================================================#
+# Go build commands
+build-linux-amd64:
+		@echo "Makefile: Building $(PROJECT_NAME) for linux/amd64"
 		@go version
-		@go build $(GO_LDFLAGS) -o k8s-kms-plugin cmd/k8s-kms-plugin/main.go
-build-debug:
+		CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=amd64 CC=$(LINUX_AMD64_CC) go build -ldflags="$(GIT_INFO_LDFLAGS) -s -w"  -o $(DIST_DIR)/$(PROJECT_NAME)_$(VERSION)_linux_amd64 cmd/k8s-kms-plugin/main.go
+
+build-linux-amd64-debug:
+		@echo "Makefile: Building $(PROJECT_NAME) for linux/amd64 with debug option"
 		@go version
-		@go build -gcflags="all=-N -l" $(GO_LDFLAGS) -o k8s-kms-plugin cmd/k8s-kms-plugin/main.go
+		CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=amd64 CC=$(LINUX_AMD64_CC) go build -gcflags="all=-N -l" -ldflags="$(GIT_INFO_LDFLAGS)" -o $(DIST_DIR)/$(PROJECT_NAME)_$(VERSION)_linux_amd64 cmd/k8s-kms-plugin/main.go
 		$(info use cmd : dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec k8s-kms-plugin)
 		$(info will listen to port 2345)
+
+build-linux-arm64:
+		@echo "Makefile: Building $(PROJECT_NAME) for linux/arm64"
+		@go version
+		CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=arm64 CC=$(LINUX_ARM64_GCC) go build -ldflags="$(GIT_INFO_LDFLAGS) -s -w" -o $(DIST_DIR)/$(PROJECT_NAME)_$(VERSION)_linux_arm64 cmd/k8s-kms-plugin/main.go
+
+build-linux-arm64-debug:
+		@echo "Makefile: Building $(PROJECT_NAME) for linux/arm64 with debug option"
+		@go version
+		CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=arm64 CC=$(LINUX_ARM64_GCC) go build -gcflags="all=-N -l" -ldflags="$(GIT_INFO_LDFLAGS)" -o $(DIST_DIR)/$(PROJECT_NAME)_$(VERSION)_linux_arm64 cmd/k8s-kms-plugin/main.go
+		$(info use cmd : dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec k8s-kms-plugin)
+		$(info will listen to port 2345)
+
+build-linux-riscv64:
+		@echo "Makefile: Building $(PROJECT_NAME) for linux/riscv64"
+		@go version
+		CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=riscv64 CC=$(LINUX_RISCV64_GCC) go build -ldflags="$(GIT_INFO_LDFLAGS) -s -w" -o $(DIST_DIR)/$(PROJECT_NAME)_$(VERSION)_linux_riscv64 cmd/k8s-kms-plugin/main.go
+
+build-linux-riscv64-debug:
+		@echo "Makefile: Building $(PROJECT_NAME) for linux/riscv64 with debug option"
+		@go version
+		CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=arm64 CC=$(LINUX_RISCV64_GCC) go build -gcflags="all=-N -l" -ldflags="$(GIT_INFO_LDFLAGS)" -o $(DIST_DIR)/$(PROJECT_NAME)_$(VERSION)_linux_riscv64 cmd/k8s-kms-plugin/main.go
+
+#==============================================================================#
 run:
 		@go run cmd/k8s-kms-plugin/main.go serve --disable-socket --enable-server --p11-lib /usr/local/lib/softhsm/libsofthsm2.so --p11-pin $(P11_PIN) --p11-label $(P11_TOKEN)
 run-test:
@@ -78,27 +122,35 @@ run-test:
 dev:
 		@skaffold dev --port-forward=true
 
-## Docs
+#==============================================================================#
+# generate Docs
 doc:
-		@go run $(GO_LDFLAGS) cmd/k8s-kms-plugin/main.go docs --output-dir docs/cli-user-interface/markdown/
-		@go run $(GO_LDFLAGS) cmd/k8s-kms-plugin/main.go docs --output-dir docs/cli-user-interface/txt/ --format cli-table-pretty
+		@go run -ldflags="$(GIT_INFO_LDFLAGS)" cmd/k8s-kms-plugin/main.go docs --output-dir docs/cli-user-interface/markdown/
+		@go run -ldflags="$(GIT_INFO_LDFLAGS)" cmd/k8s-kms-plugin/main.go docs --output-dir docs/cli-user-interface/txt/ --format cli-table-pretty
 
-## Testing
-
+#==============================================================================#
+# Testing
 p11tool-list:
 		@kubectl exec -it k8s-kms-plugin-server -- p11tool --lib /usr/lib/softhsm/libsofthsm2.so --pin changeme --token default list
 
 p11tool-delete:
 		@kubectl exec -it k8s-kms-plugin-server -- p11tool --lib /usr/lib/softhsm/libsofthsm2.so --pin $(P11_PIN) --token $(P11_TOKEN) delete
 
-
-## Deploy
-
+#==============================================================================#
+# Deploy & CICD release
 deploy:
 		@gcloud endpoints services deploy --format json "./apis/api-service.yaml" "./apis/istio/v1/v1.pb"  > "./deployed.json"
 
 release: 
 		@echo "Makefile: Running goreleaser release --clean fro project $(PROJECT_NAME)"
-		LDFLAGS=$(LDFLAGS) goreleaser release --clean --skip sign,validate,ko
+		LDFLAGS="$(GIT_INFO_LDFLAGS) -s -w" goreleaser release --clean --skip sign,validate,ko
+
 get-ldflags:
-		@echo $(LDFLAGS)
+		@echo "$(GIT_INFO_LDFLAGS) -s -w"
+
+#==============================================================================#
+# Clean command
+clean:
+	@echo "Makefile: cleaning dist file"
+	$(GO_CLEAN)
+	rm -rf $(DIST_DIR)

--- a/README.md
+++ b/README.md
@@ -527,12 +527,10 @@ They are signed by a tool named cosign using a keyless mode.
 It required an authentication by clicking in links present in logs.
 
 ![Screenshot of one example of logs containing three authentication links generating tokens](docs/images/cosign/AuthLinksCosign.png)
-![Screenshot of one example of logs containing three authentication links generating tokens](docs/images/cosign/AuthLinksCosign.png)
 
 Once you click on one, you can submit a verification code that will redirect you to three types of authentication. Then click on Github authentication.
 
- ![Screenshot of the interface for submitting a code](docs/images/cosign/CodeSubmit.png)
- ![Screenshot of the interface for submitting a code](docs/images/cosign/CodeSubmit.png)
+![Screenshot of the interface for submitting a code](docs/images/cosign/CodeSubmit.png)
 
 Do these actions for every authentication links and the signatures and the certificates will be generated with the artifacts in the release.
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ TL;DR: For a quick start experience, try the `k8s-kms-plugin` with software (vir
     - [3.2.5. Binary](#325-binary)
   - [3.3. Build `k8s-kms-plugin` locally from Source with `make`](#33-build-k8s-kms-plugin-locally-from-source-with-make)
     - [3.3.1. Build Requirements](#331-build-requirements)
-    - [3.3.2. Standard x86 Linux Build](#332-standard-x86-linux-build)
-    - [3.3.3. Debug x86 Linux Build](#333-debug-x86-linux-build)
+    - [3.3.2. Build `linux/amd64`](#332-build-linuxamd64)
+    - [3.3.3. Build `linux/amd64` Debug](#333-build-linuxamd64-debug)
+    - [3.3.4. Build `linux/aarch64`](#334-build-linuxaarch64)
+    - [3.3.5. Build `linux/aarch64` Debug](#335-build-linuxaarch64-debug)
+    - [3.3.6. Build `linux/riscv64`](#336-build-linuxriscv64)
+    - [3.3.7. Build `linux/riscv64` Debug](#337-build-linuxriscv64-debug)
   - [3.4. Build `k8s-kms-plugin` **locally** from Source with `goreleaser`](#34-build-k8s-kms-plugin-locally-from-source-with-goreleaser)
 - [4. Documentation, Usage \& User Guides 📚](#4-documentation-usage--user-guides-)
   - [4.1. CLI Help Messages](#41-cli-help-messages)
@@ -193,8 +197,22 @@ Until the packages are available on official repos and signed, you can install t
 
 Example on Wolfi OS:
 
+**amd64 x86_64**:
+
 ```bash
-apk add --allow-untrusted ./k8s-kms-plugin_SNAPSHOT-3239cd9_x86_64.apk
+apk add --allow-untrusted ./k8s-kms-plugin_0.8.0_test2-ga_x86_64.apk
+```
+
+**arm64 aarch64**:
+
+```bash
+apk add --allow-untrusted ./k8s-kms-plugin_0.8.0_test2-ga_aarch64.apk
+```
+
+**riscv64 riscv64**:
+
+```bash
+apk add --allow-untrusted ./k8s-kms-plugin_0.8.0_test2-ga_riscv64.apk
 ```
 
 #### 3.2.2. `archlinux` packages
@@ -203,9 +221,21 @@ See https://wiki.archlinux.org/title/Pacman#Additional_commands
 
 Command should look like this:
 
+**amd64 x86_64**:
+
 ```bash
-pacman -U ./k8s-kms-plugin-SNAPSHOT-3239cd9-1-x86_64.pkg.tar.zst
+pacman -U ./k8s-kms-plugin-0.8.0_test2-ga-1-x86_64.pkg.tar.zst
 ```
+
+**arm64 aarch64**:
+
+```bash
+pacman -U ./k8s-kms-plugin-0.8.0_test2-ga-1-aarch64.pkg.tar.zst
+```
+
+**riscv64 riscv64**:
+
+Building `riscv64` from `goreleaser` for `archilinux` is not supported yet.
 
 However, pacman needs a version that follows semantic versionning. Make sure you use the right package that uses semver, otherwise you get this error:
 
@@ -218,8 +248,10 @@ error: './k8s-kms-plugin-SNAPSHOT-3239cd9-1-x86_64.pkg.tar.zst': invalid or corr
 
 If you wish to install a snapshot version of `k8s-kms-plugin` (not following semantic versionning), you will need to use the following command `dpkg -i --force-all` to force the installation of the package. Otherwise, `dpkg` will fail with the following error:
 
+**amd64 x86_64**:
+
 ```bash
-$ sudo dpkg -i ./k8s-kms-plugin_SNAPSHOT-3239cd9_amd64.deb 
+$ sudo dpkg -i ./k8s-kms-plugin_0.8.0_test2-ga_amd64.deb
 ```
 ```
 dpkg: error processing archive ./k8s-kms-plugin_SNAPSHOT-3239cd9_amd64.deb (--install):
@@ -231,8 +263,10 @@ Errors were encountered while processing:
 
 "Force" will only raise a warning:
 
+**amd64 x86_64**:
+
 ```bash
-dpkg --force-all -i ./k8s-kms-plugin_SNAPSHOT-3239cd9_amd64.deb
+dpkg --force-all -i ./k8s-kms-plugin_0.8.0_test2-ga_amd64.deb
 ```
 
 ```
@@ -245,26 +279,68 @@ Unpacking k8s-kms-plugin (SNAPSHOT-3239cd9) ...
 Setting up k8s-kms-plugin (SNAPSHOT-3239cd9) ...
 ```
 
-#### 3.2.4. `rpm` RPM packages
+**arm64 aarch64**:
 
 ```bash
-dnf install ./k8s-kms-plugin-SNAPSHOT-3239cd9-1.x86_64.rpm
+dpkg --force-all -i ./k8s-kms-plugin_0.8.0_test2-ga_arm64.deb
+```
+
+**riscv64 riscv64**:
+
+```bash
+dpkg --force-all -i ./k8s-kms-plugin_0.8.0_test2-ga_riscv64.deb
+```
+
+#### 3.2.4. `rpm` RPM packages
+
+**amd64 x86_64**:
+
+```bash
+dnf install ./k8s-kms-plugin-0.8.0_test2_ga-1.x86_64.rpm
+```
+
+**arm64 aarch64**:
+
+```bash
+dnf install ./k8s-kms-plugin-0.8.0_test2_ga-1.aarch64.rpm
+```
+
+**riscv64 riscv64**:
+
+```bash
+dnf install ./k8s-kms-plugin-0.8.0_test2_ga-1.riscv64.rpm
 ```
 
 #### 3.2.5. Binary
 
 Move the `k8s-kms-plugin` binary to a relevant location under your `$PATH`, for example `/usr/local/bin/k8s-kms-plugin`.
 
+On Github Actions, the `k8s-kms-plugin` binary is available in the release page for amd64 x86_64, arm64 (aarch64) and riscv64.
+
 ### 3.3. Build `k8s-kms-plugin` locally from Source with `make`
 
 #### 3.3.1. Build Requirements
 
-You should have `make`, `git` and `go` installed. Review the content of the [`Makefile`](./Makefile) file for more details.
+On an amd64 x86 linux environment, you need to install:
+  * `make`
+  * `gcc`
+  * `git`
+  * `go`
+  * `gcc-aarch64-linux-gnu` (mandatory, needed if you wish to cross compile from amd64 x86 to aarch64 arm64)
+  * `gcc-riscv64-linux-gnu` (mandatory, needed if you wish to cross compile from amd64 x86 to riscv64)
+  * `libc6-dev-arm64-cross` (optional for now)
+  * `libc6-dev-riscv64-cross` (optional for now)
+
+> Note: Building from a macOS or Windows environment is not supported by this documentation.
+
+Review the content of the [`Makefile`](./Makefile) file for more details.
 
 **`CGO`** is required to build the plugin: **make sure you are using the right C Library** (glibc or musl) for your target
 environment. Do not build on musl libc if you intend to use the plugin on a non-musl environment (glibc).
 
-Build was tested with:
+Build was tested on an amd64 x86 linux environment with:
+
+**make**
 
 ```bash
 make --version
@@ -278,16 +354,48 @@ This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.
 ```
 
-GoLang
+**gcc**
+
+```bash
+gcc --version
+```
+```
+gcc (Debian 12.2.0-14+deb12u1) 12.2.0
+Copyright (C) 2022 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+```
+
+```bash
+aarch64-linux-gnu-gcc --version
+```
+```
+aarch64-linux-gnu-gcc (Debian 12.2.0-14) 12.2.0
+Copyright (C) 2022 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+```
+
+```bash
+riscv64-linux-gnu-gcc --version
+```
+```
+riscv64-linux-gnu-gcc (Debian 12.2.0-13) 12.2.0
+Copyright (C) 2022 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+```
+
+**GoLang**
 
 ```bash
 go version
 ```
 ```
-go version go1.23.9 linux/amd64
+go version go1.24.5 linux/amd64
 ```
 
-Git
+**Git**
 
 ```bash
 git version
@@ -296,27 +404,87 @@ git version
 git version 2.50.1
 ```
 
-#### 3.3.2. Standard x86 Linux Build
+#### 3.3.2. Build `linux/amd64`
 
 Run
 
 ```bash
-make build
+make build-linux-amd64
 ```
 
 You should get a `k8s-kms-plugin` binary in the current directory.
 
-#### 3.3.3. Debug x86 Linux Build
+#### 3.3.3. Build `linux/amd64` Debug
 
 Run
 
 ```bash
-make build-debug
+make build-linux-amd64-debug
 ```
 
 You should get a `k8s-kms-plugin` binary in the current directory.
+
+#### 3.3.4. Build `linux/aarch64`
+
+```bash
+make build-linux-aarch64
+```
+
+#### 3.3.5. Build `linux/aarch64` Debug
+
+```bash
+make build-linux-aarch64-debug
+```
+
+#### 3.3.6. Build `linux/riscv64`
+
+```bash
+make build-linux-riscv64
+```
+
+#### 3.3.7. Build `linux/riscv64` Debug
+
+```bash
+make build-linux-riscv64-debug
+```
 
 ### 3.4. Build `k8s-kms-plugin` **locally** from Source with `goreleaser`
+
+> 🚧 **Note** 🚧: This section needs to be updated to fully support building for `linux/aarch64` and `linux/riscv64`.
+> Indeed, for now image `ghcr.io/thalesgroup/goreleaser-glibc-image:golang-1.24.5-bookworm` only supports `linux/arm64` x86. If you wish to build for `linux/aarch64` and `linux/riscv64`, you need to manually install `gcc-aarch64-linux-gnu` and `gcc-riscv64-linux-gnu` on this image.
+>
+> You can do so by using `ghcr.io/thalesgroup/goreleaser-glibc-image-base` base image and entering inside the container as follows:
+>
+> ```bash
+> podman run -it --rm \
+              -v $PWD:/pwd \
+              --workdir /pwd \
+              -e LDFLAGS=$LDFLAGS \
+              -e WORKSPACE=$WORKSPACE \
+              -e GITHUB_REPOSITORY_OWNER=$GITHUB_REPOSITORY_OWNER \
+              --platform "linux/amd64" \
+      ghcr.io/thalesgroup/goreleaser-glibc-image-base:golang-1.24.5-bookworm
+> ```
+> 
+> Then from inside the container, install the required packages:
+>
+> ```bash
+> apt-get update && \
+> apt-get install -y \
+>   gcc-aarch64-linux-gnu \
+>   gcc-riscv64-linux-gnu
+> ```
+>
+> Then from inside the container, you can run goreleaser as follows:
+>
+> ```bash
+> goreleaser release \
+>   --clean \
+>   --snapshot \
+>   --skip sign,publish,validate,ko,sbom
+> ```
+>
+> The objective is to add support for `linux/aarch64` and `linux/riscv64` to image `ghcr.io/thalesgroup/goreleaser-glibc-image*` in a future version.
 
 This section allows you to locally test the [`goreleaser`](https://github.com/goreleaser/goreleaser) Github Action Build
 Recipe. It generates the same artefacts that the one generated by the Github Action CICD pipeline, but locally.

--- a/pkg/providers/p11.go
+++ b/pkg/providers/p11.go
@@ -717,7 +717,6 @@ func (p *P11) decryptWithContext(req *k8skmsv2.DecryptRequest, isRotation bool) 
 			}
 		case jose.AlgRSAOAEP:
 			logrus.Tracef("p11:Decrypt case %s", jose.AlgRSAOAEP)
-			logrus.Tracef("p11:Decrypt case %s", jose.AlgRSAOAEP)
 			// load pkcs11 context
 			var rsaKeyPair crypto11.SignerDecrypter
 			if rsaKeyPair, err = actualCtx.FindRSAKeyPair(reqKekKeyIdByteA, nil); err != nil {
@@ -779,7 +778,6 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 		switch p.algorithm {
 		case jose.AlgA256GCM:
 			logrus.Tracef("p11:Encrypt case %s", jose.AlgA256GCM)
-			logrus.Tracef("p11:Encrypt case %s", jose.AlgA256GCM)
 			// Find the KEK in the KMS
 			var kek *crypto11.SecretKey
 			if kek, err = p.ctx.FindKey(p.kekCkaId, p.GetKekCkaLabelByteA()); nil != err {
@@ -812,7 +810,6 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 			}
 
 		case jose.AlgA256CBC:
-			logrus.Tracef("p11:Encrypt case %s", jose.AlgA256CBC)
 			logrus.Tracef("p11:Encrypt case %s", jose.AlgA256CBC)
 			// Find the KEK in the KMS
 			var kek *crypto11.SecretKey
@@ -864,7 +861,6 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 			}
 
 		case jose.AlgRSAOAEP:
-			logrus.Tracef("p11:Encrypt case %s", jose.AlgRSAOAEP)
 			logrus.Tracef("p11:Encrypt case %s", jose.AlgRSAOAEP)
 			//TODO generate a jwk with the kid of the public key. Ex :
 			//      {"kty":"EC",

--- a/pkg/providers/p11_test.go
+++ b/pkg/providers/p11_test.go
@@ -7,15 +7,6 @@
  * https://opensource.org/licenses/MIT.
  */
 
-/*
- * Copyright 2025 Thales Group
- * SPDX-License-Identifier: MIT
- *
- * Use of this source code is governed by an MIT-style
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/MIT.
- */
-
 package providers
 
 import (


### PR DESCRIPTION

* Github Actions (GA): Update to newer versions
* GA: Add cross-compilation support for aarch64 & riscv64
* GA: update SLSA job
* GA: Golang job uses the same Go version than the one in the go.mod
* Goreleaser: add build support for aarch64 & riscv64
* Makefile: add build support for aarch64 & riscv64
* README: update build doc
* P11: remove duplicat log lines
* p11_testt: remove duplicate header