### PR TITLE
replace logrus with log/slog across all packages (#1)

### DIFF
--- a/cmd/k8s-kms-plugin/cmd/decrypt-csr.go
+++ b/cmd/k8s-kms-plugin/cmd/decrypt-csr.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -18,7 +18,8 @@ import (
 	"time"
 
 	istio "github.com/ThalesGroup/k8s-kms-plugin/apis/istio/v1"
-	"github.com/sirupsen/logrus"
+	"log/slog"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -49,7 +50,7 @@ var decryptCSRCmd = &cobra.Command{
 	// Initialize and populate cobra CLI flags values with viper during the Persistent pre-run
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := InitViperSubCmdE(viper.GetViper(), cmd, &vprFlgsDecryptCSR); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Error("Error initializing Viper")
+			slog.Error("Error initializing Viper", "cobra_cmd", cmd.Use, "error", err)
 			return err
 		}
 		return nil

--- a/cmd/k8s-kms-plugin/cmd/docs.go
+++ b/cmd/k8s-kms-plugin/cmd/docs.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -10,14 +10,16 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/ThalesGroup/k8s-kms-plugin/pkg/logging"
 	"github.com/ThalesGroup/k8s-kms-plugin/pkg/version"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"github.com/spf13/pflag"
@@ -43,7 +45,7 @@ var docsCmd = &cobra.Command{
 	// Initialize and populate cobra CLI flags values with viper during the Persistent pre-run
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := InitViperSubCmdE(viper.GetViper(), cmd, &vprFlgsDocs); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Error("Error initializing Viper")
+			slog.Error("Error initializing Viper", "cobra_cmd", cmd.Use, "error", err)
 			return err
 		}
 		return nil
@@ -51,7 +53,7 @@ var docsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := generateCobraDocs(vprFlgsDocs.Format, vprFlgsDocs.OutputDir)
 		if err != nil {
-			logrus.WithError(err).Errorf("Error generating docs in format %s at %s", vprFlgsDocs.Format, vprFlgsDocs.OutputDir)
+			slog.Error("error generating docs", "format", vprFlgsDocs.Format, "output_dir", vprFlgsDocs.OutputDir, "error", err)
 		}
 		return err
 	},
@@ -262,7 +264,7 @@ func writeMarkdownReadme(dir string) error {
 func generateCobraDocs(format, out string) error {
 	// Create the output directory if it doesn't already exist
 	if _, err := os.Stat(out); os.IsNotExist(err) {
-		logrus.Tracef("Creating output directory %s", out)
+		slog.Log(context.Background(), logging.LevelTrace, "creating output directory", "path", out)
 		if err := os.MkdirAll(out, 0755); err != nil {
 			return fmt.Errorf("error creating output directory %s: %w", out, err)
 		}
@@ -279,7 +281,7 @@ func generateCobraDocs(format, out string) error {
 	// TODO: improve and clean this switch case
 	switch format {
 	case "markdown":
-		logrus.Tracef("Generating markdown documentation at %s", out)
+		slog.Log(context.Background(), logging.LevelTrace, "generating markdown documentation", "path", out)
 		if err := writeFlagTableToFile(rootCmd, format, filepath.Join(out, "cli-env-var-table.md")); err != nil {
 			return fmt.Errorf("error writing flag table to file: %w", err)
 		}
@@ -292,7 +294,7 @@ func generateCobraDocs(format, out string) error {
 		}
 		return nil
 	case "man":
-		logrus.Tracef("Generating man documentation at %s", out)
+		slog.Log(context.Background(), logging.LevelTrace, "generating man documentation", "path", out)
 		if err := writeFlagTableToFile(rootCmd, "", filepath.Join(out, "cli-env-var-table.txt")); err != nil {
 			return fmt.Errorf("error writing flag table to file: %w", err)
 		}
@@ -302,7 +304,7 @@ func generateCobraDocs(format, out string) error {
 		}
 		return nil
 	case "rst":
-		logrus.Tracef("Generating rst documentation at %s", out)
+		slog.Log(context.Background(), logging.LevelTrace, "generating rst documentation", "path", out)
 		if err := writeFlagTableToFile(rootCmd, "", filepath.Join(out, "cli-env-var-table.txt")); err != nil {
 			return fmt.Errorf("error writing flag table to file: %w", err)
 		}
@@ -311,7 +313,7 @@ func generateCobraDocs(format, out string) error {
 		}
 		return nil
 	case "yaml":
-		logrus.Tracef("Generating yaml documentation at %s", out)
+		slog.Log(context.Background(), logging.LevelTrace, "generating yaml documentation", "path", out)
 		if err := writeFlagTableToFile(rootCmd, "", filepath.Join(out, "cli-env-var-table.txt")); err != nil {
 			return fmt.Errorf("error writing flag table to file: %w", err)
 		}
@@ -320,19 +322,19 @@ func generateCobraDocs(format, out string) error {
 		}
 		return nil
 	case "cli-table-csv":
-		logrus.Tracef("Generating table documentation at %s", out)
+		slog.Log(context.Background(), logging.LevelTrace, "generating table documentation", "path", out)
 		if err := writeFlagTableToFile(rootCmd, "csv", filepath.Join(out, "cli-env-var-table.csv")); err != nil {
 			return fmt.Errorf("error writing flag table to file: %w", err)
 		}
 		return nil
 	case "cli-table-pretty":
-		logrus.Tracef("Generating table documentation at %s", out)
+		slog.Log(context.Background(), logging.LevelTrace, "generating table documentation", "path", out)
 		if err := writeFlagTableToFile(rootCmd, "", filepath.Join(out, "cli-env-var-table.txt")); err != nil {
 			return fmt.Errorf("error writing flag table to file: %w", err)
 		}
 		return nil
 	case "cli-table-html":
-		logrus.Tracef("Generating table documentation at %s", out)
+		slog.Log(context.Background(), logging.LevelTrace, "generating table documentation", "path", out)
 		if err := writeFlagTableToFile(rootCmd, "html", filepath.Join(out, "cli-env-var-table.html")); err != nil {
 			return fmt.Errorf("error writing flag table to file: %w", err)
 		}
@@ -340,7 +342,7 @@ func generateCobraDocs(format, out string) error {
 	case "all":
 		for _, dir := range []string{"rst", "markdown", "man", "yaml", "csv", "html", "txt"} {
 			if _, err := os.Stat(filepath.Join(out, dir)); os.IsNotExist(err) {
-				logrus.Tracef("Creating output directory %s", filepath.Join(out, dir))
+				slog.Log(context.Background(), logging.LevelTrace, "creating output directory", "path", filepath.Join(out, dir))
 				if err := os.MkdirAll(filepath.Join(out, dir), 0755); err != nil {
 					return fmt.Errorf("error creating output directory %s: %w", filepath.Join(out, dir), err)
 				}
@@ -349,7 +351,7 @@ func generateCobraDocs(format, out string) error {
 			}
 		}
 
-		logrus.Tracef("Generating all documentation at %s", out)
+		slog.Log(context.Background(), logging.LevelTrace, "generating all documentation", "path", out)
 		// markdown
 		if err := doc.GenMarkdownTree(rootCmd, filepath.Join(out, "markdown")); err != nil {
 			return fmt.Errorf("error generating markdown documentation: %w", err)

--- a/cmd/k8s-kms-plugin/cmd/generate-kek.go
+++ b/cmd/k8s-kms-plugin/cmd/generate-kek.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -16,7 +16,8 @@ import (
 	"time"
 
 	istio "github.com/ThalesGroup/k8s-kms-plugin/apis/istio/v1"
-	"github.com/sirupsen/logrus"
+	"log/slog"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -39,7 +40,7 @@ var generateKEKCmd = &cobra.Command{
 	// Initialize and populate cobra CLI flags values with viper during the Persistent pre-run
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := InitViperSubCmdE(viper.GetViper(), cmd, &vprFlgsGenerateKEK); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Error("Error initializing Viper")
+			slog.Error("Error initializing Viper", "cobra_cmd", cmd.Use, "error", err)
 			return err
 		}
 		return nil

--- a/cmd/k8s-kms-plugin/cmd/import-ca.go
+++ b/cmd/k8s-kms-plugin/cmd/import-ca.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -16,7 +16,8 @@ import (
 	"time"
 
 	istio "github.com/ThalesGroup/k8s-kms-plugin/apis/istio/v1"
-	"github.com/sirupsen/logrus"
+	"log/slog"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -44,7 +45,7 @@ var importCaCmd = &cobra.Command{
 	// Initialize and populate cobra CLI flags values with viper during the Persistent pre-run
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := InitViperSubCmdE(viper.GetViper(), cmd, &vprFlgsImportCa); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Error("Error initializing Viper")
+			slog.Error("Error initializing Viper", "cobra_cmd", cmd.Use, "error", err)
 			return err
 		}
 		return nil

--- a/cmd/k8s-kms-plugin/cmd/root.go
+++ b/cmd/k8s-kms-plugin/cmd/root.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -11,13 +11,12 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"time"
 
-	filename "github.com/keepeye/logrus-filename"
-	"github.com/sirupsen/logrus"
-
-	"os"
-
+	"github.com/ThalesGroup/k8s-kms-plugin/pkg/logging"
+	"github.com/lmittmann/tint"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -43,6 +42,9 @@ type ViperFlagsRoot struct {
 // Declare the viper CLI flag values buffer
 var vprFlgsRoot ViperFlagsRoot
 
+// activeLogLevel is the runtime-adjustable log level shared by all slog handlers.
+var activeLogLevel = new(slog.LevelVar)
+
 // cobra root CLI flags default value
 const (
 	defaultKekId = "a37807cd-6d1a-4d75-813a-e120f30176f7" // TODO: with KMS v2, consider not using this hardcoded value
@@ -61,7 +63,7 @@ k8s-kms-plugin prioritizes configuration sources as follows: CLI flags > environ
 Project Page: https://github.com/ThalesGroup/k8s-kms-plugin
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logrus.Warn("No subcommand provided. Please use one of the available subcommands. Showing help message.")
+		slog.Warn("No subcommand provided. Please use one of the available subcommands. Showing help message.")
 		return cmd.Help()
 	},
 }
@@ -69,10 +71,6 @@ Project Page: https://github.com/ThalesGroup/k8s-kms-plugin
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	filenameHook := filename.NewHook()
-	filenameHook.Field = "line"
-	logrus.AddHook(filenameHook)
-
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -108,12 +106,12 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "k8s-kms-plugin.config.yaml", "ConfigFile. Env var: K8S_KMS_PLUGIN_CONFIG_FILE")
 
 	// logging level
-	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Set logrus.SetLevel to \"debug\". This is equivalent to using --log-level=debug. Flags --log-level and --debug flag are mutually exclusive. Env var: K8S_KMS_PLUGIN_DEBUG.")
-	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Set logrus.SetLevel. Possible values: trace, debug, info, warning, error, fatal and panic. Flags --log-level and --debug flag are mutually exclusive. Env var: K8S_KMS_PLUGIN_LOG_LEVEL.")
+	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Set log level to \"debug\". This is equivalent to using --log-level=debug. Flags --log-level and --debug flag are mutually exclusive. Env var: K8S_KMS_PLUGIN_DEBUG.")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Set log level. Possible values: trace, debug, info, warn, error, quiet. Flags --log-level and --debug flag are mutually exclusive. Env var: K8S_KMS_PLUGIN_LOG_LEVEL.")
 	rootCmd.RegisterFlagCompletionFunc("log-level", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"trace", "debug", "info", "warning", "error", "fatal", "panic"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"trace", "debug", "info", "warn", "error", "quiet"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Logrus log output format. Possible values: text, json. Env var: K8S_KMS_PLUGIN_LOG_FORMAT")
+	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log output format. Possible values: text, json. Env var: K8S_KMS_PLUGIN_LOG_FORMAT")
 	rootCmd.RegisterFlagCompletionFunc("log-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"text", "json"}, cobra.ShellCompDirectiveNoFileComp
 	})
@@ -128,40 +126,42 @@ func initConfig() {
 	// Initialize and populate cobra CLI root flags values with viper
 	InitViperSubCmdE(viper.GetViper(), rootCmd, &vprFlgsRoot)
 
-	// Set logs format
+	// Determine log level
+	if rootCmd.Flags().Lookup("debug").Changed {
+		activeLogLevel.Set(slog.LevelDebug)
+	} else {
+		level, err := logging.ParseLevel(vprFlgsRoot.LogLevel)
+		if err != nil {
+			slog.Error("unknown log level", "error", err)
+		}
+		activeLogLevel.Set(level)
+		if level == logging.LevelQuiet {
+			slog.SetDefault(slog.New(slog.DiscardHandler))
+			return
+		}
+	}
+
+	// Build slog handler based on requested format
+	opts := &tint.Options{
+		Level:      activeLogLevel,
+		TimeFormat: time.DateTime,
+		AddSource:  true,
+	}
+	var handler slog.Handler
 	switch vprFlgsRoot.LogFormat {
 	case "json":
-		logrus.SetFormatter(&logrus.JSONFormatter{
-			PrettyPrint:      false,
-			DisableTimestamp: false,
-			TimestampFormat:  time.RFC3339,
+		handler = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+			Level:     activeLogLevel,
+			AddSource: true,
 		})
 	case "text":
-		logrus.SetFormatter(&logrus.TextFormatter{
-			ForceColors:      true,
-			DisableTimestamp: false,
-			TimestampFormat:  time.DateTime,
-		})
+		handler = tint.NewHandler(os.Stderr, opts)
 	default:
-		logrus.WithError(fmt.Errorf("logrus unknown output format")).Error("unknown log format")
+		handler = tint.NewHandler(os.Stderr, opts)
+		slog.Error("unknown log format", "format", vprFlgsRoot.LogFormat)
 	}
-	logrus.Debugf("logrus output format is set to: %s", vprFlgsRoot.LogFormat)
+	slog.SetDefault(slog.New(handler))
 
-	// Initialize logrus log level and log format for all cobra commands and subcommands.
-	debugFlagIsUsed := rootCmd.Flags().Lookup("debug").Changed
-
-	switch {
-	case debugFlagIsUsed:
-		// harcode that the --debug flags set logrus level to debug
-		logrus.SetLevel(logrus.DebugLevel)
-	default:
-		// get the log level from viper which is bind to the cobra flag --log-level
-		level, err := logrus.ParseLevel(vprFlgsRoot.LogLevel)
-		if err != nil {
-			logrus.WithError(err).Error("unknown log level")
-		}
-		logrus.SetLevel(level)
-	}
-	logrus.Debugf("logrus log-level is set to: %s", logrus.GetLevel())
-
+	slog.Debug("log format configured", "log_format", vprFlgsRoot.LogFormat)
+	slog.Debug("log level configured", "log_level", activeLogLevel.Level())
 }

--- a/cmd/k8s-kms-plugin/cmd/rotation.go
+++ b/cmd/k8s-kms-plugin/cmd/rotation.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -10,16 +10,18 @@
 package cmd
 
 import (
+	"context"
 	"errors"
+	"log/slog"
 	"net"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/ThalesGroup/crypto11"
+	"github.com/ThalesGroup/k8s-kms-plugin/pkg/logging"
 	"github.com/ThalesGroup/k8s-kms-plugin/pkg/providers"
 	"github.com/ThalesGroup/k8s-kms-plugin/pkg/version"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
@@ -92,7 +94,7 @@ Using both CLI Flags, environment variables and configuration file and serving o
 	`,
 	// Initialize and populate cobra CLI flags values with viper during the Persistent pre-run
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		// Manually call parent’s PersistentPreRunE
+		// Manually call parent's PersistentPreRunE
 		if cmd.Parent() != nil && cmd.Parent().PersistentPreRunE != nil {
 			if err := cmd.Parent().PersistentPreRunE(cmd.Parent(), args); err != nil {
 				return err
@@ -100,14 +102,14 @@ Using both CLI Flags, environment variables and configuration file and serving o
 		}
 
 		if err := InitViperSubCmdE(viper.GetViper(), cmd, &vprFlgsRotation); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Error("Error initializing Viper")
+			slog.Error("Error initializing Viper", "cobra_cmd", cmd.Use, "error", err)
 			return err
 		}
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		// Show the version of the k8s-kms-plugin and commit ID
-		version.LogrusOutputVersion()
+		version.LogVersion()
 
 		// provider for the KEK that is being rotated, aka the old KEK
 		var p providers.Provider
@@ -116,19 +118,13 @@ Using both CLI Flags, environment variables and configuration file and serving o
 		if err != nil && providers.IsPKCS11AuthenticationError(err) {
 			// Don't panic/exit if we have a PKCS#11 error.
 			// Sleep forever instead.
-			logrus.WithField("cobra-cmd", cmd.Use).
-				WithError(err).
-				Error("PKCS11 authentication error detected. Further retries may cause the token to be erased.")
-			logrus.WithField("cobra-cmd", cmd.Use).Warn("Process will now sleep indefinitely to prevent further damage...")
+			slog.Error("PKCS11 authentication error detected. Further retries may cause the token to be erased.", "cobra_cmd", cmd.Use, "error", err)
+			slog.Warn("Process will now sleep indefinitely to prevent further damage...", "cobra_cmd", cmd.Use)
 			time.Sleep(8760 * time.Hour)
 		}
 
 		if err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Fatal("failed to initialize rotated provider for old KEK")
-		}
-
-		if err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Fatal("failed to initialize provider for new KEK")
+			logging.Fatal("failed to initialize rotated provider for old KEK", "cobra_cmd", cmd.Use, "error", err)
 		}
 
 		// gRPC server
@@ -160,7 +156,7 @@ Using both CLI Flags, environment variables and configuration file and serving o
 		}
 
 		if err = g.Wait(); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).Error(err)
+			slog.Error("gRPC server error", "cobra_cmd", cmd.Use, "error", err)
 		}
 
 		return nil
@@ -207,7 +203,7 @@ func initRotatedProvider() (pRot providers.Provider, err error) {
 	activeConfig := &crypto11.Config{}
 	switch vprFlgsServe.Provider {
 	case "p11", "softhsm":
-		logrus.Debug("initProvider: case p11 or softhsm")
+		slog.Debug("initProvider: case p11 or softhsm")
 		activeConfig = &crypto11.Config{
 			Path:            vprFlgsServe.P11Lib,
 			Pin:             vprFlgsServe.P11Pin,
@@ -215,7 +211,7 @@ func initRotatedProvider() (pRot providers.Provider, err error) {
 		}
 
 	case "luna", "dpod":
-		logrus.Debug("initProvider: case luna HSM or dpod")
+		slog.Debug("initProvider: case luna HSM or dpod")
 		activeConfig = &crypto11.Config{
 			Path:            vprFlgsServe.P11Lib,
 			Pin:             vprFlgsServe.P11Pin,
@@ -226,7 +222,7 @@ func initRotatedProvider() (pRot providers.Provider, err error) {
 			},
 		}
 	default:
-		logrus.WithField("provider", vprFlgsServe.Provider).Error("unknown provider")
+		slog.Error("unknown provider", "provider", vprFlgsServe.Provider)
 		err = errors.New("unknown provider")
 		return
 	}
@@ -248,7 +244,7 @@ func initRotatedProvider() (pRot providers.Provider, err error) {
 	oldConfig := &crypto11.Config{}
 	switch vprFlgsRotation.OldProvider {
 	case "p11", "softhsm":
-		logrus.Debug("initProvider: case p11 or softhsm")
+		slog.Debug("initProvider: case p11 or softhsm")
 		oldConfig = &crypto11.Config{
 			Path:            vprFlgsRotation.OldP11Lib,
 			Pin:             vprFlgsRotation.OldP11Pin,
@@ -256,7 +252,7 @@ func initRotatedProvider() (pRot providers.Provider, err error) {
 		}
 
 	case "luna", "dpod":
-		logrus.Debug("initProvider: case luna HSM or dpod")
+		slog.Debug("initProvider: case luna HSM or dpod")
 		oldConfig = &crypto11.Config{
 			Path:            vprFlgsRotation.OldP11Lib,
 			Pin:             vprFlgsRotation.OldP11Pin,
@@ -267,7 +263,7 @@ func initRotatedProvider() (pRot providers.Provider, err error) {
 			},
 		}
 	default:
-		logrus.WithField("provider", vprFlgsRotation.OldProvider).Error("unknown provider")
+		slog.Error("unknown provider", "provider", vprFlgsRotation.OldProvider)
 		err = errors.New("unknown provider")
 		return
 	}
@@ -301,7 +297,7 @@ func initRotatedProvider() (pRot providers.Provider, err error) {
 }
 
 func grpcRotation(gl net.Listener, p providers.Provider) (err error) {
-	logrus.Trace("grpcRotation")
+	slog.Log(context.Background(), logging.LevelTrace, "grpcRotation")
 
 	// Create a gRPC server to host the services
 	serverOptions := []grpc.ServerOption{
@@ -313,12 +309,12 @@ func grpcRotation(gl net.Listener, p providers.Provider) (err error) {
 	k8skmsv2.RegisterKeyManagementServiceServer(gs, p)
 	reflection.Register(gs)
 
-	logrus.Infof("Serving on socket: %s", gl.Addr().String())
-	logrus.Debugf("grpcRotation: value of grpcPort user input: %d", vprFlgsServe.Port)
+	slog.Info("serving on socket", "address", gl.Addr().String())
+	slog.Debug("grpc port", "port", vprFlgsServe.Port)
 
 START:
 	if err = gs.Serve(gl); err != nil {
-		logrus.Error(err)
+		slog.Error("gRPC serve error", "error", err)
 		goto START
 	}
 	return

--- a/cmd/k8s-kms-plugin/cmd/serve.go
+++ b/cmd/k8s-kms-plugin/cmd/serve.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -13,7 +13,9 @@ package cmd
 //   - gose
 //   - crypto11
 import (
+	"context"
 	"errors"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -29,8 +31,8 @@ import (
 	version "github.com/ThalesGroup/k8s-kms-plugin/pkg/version"
 	k8skmsv2 "k8s.io/kms/apis/v2"
 
+	"github.com/ThalesGroup/k8s-kms-plugin/pkg/logging"
 	"github.com/ThalesGroup/k8s-kms-plugin/pkg/providers"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
@@ -141,29 +143,27 @@ Using AES-CBC with HMAC authentication, using CKA_ID, using CLI flags and servin
 	// Initialize and populate cobra CLI flags values with viper during the Persistent pre-run
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := InitViperSubCmdE(viper.GetViper(), cmd, &vprFlgsServe); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Error("Error initializing Viper")
+			slog.Error("Error initializing Viper", "cobra_cmd", cmd.Use, "error", err)
 			return err
 		}
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		// Show the version of the k8s-kms-plugin and commit ID
-		version.LogrusOutputVersion()
+		version.LogVersion()
 
 		// Don't panic/exit if we have a PKCS#11 error.
 		// Sleep forever instead.
 		var p providers.Provider
 		p, err = initProvider()
 		if err != nil && providers.IsPKCS11AuthenticationError(err) {
-			logrus.WithField("cobra-cmd", cmd.Use).
-				WithError(err).
-				Error("PKCS11 authentication error detected. Further retries may cause the token to be erased.")
-			logrus.WithField("cobra-cmd", cmd.Use).Warn("Process will now sleep indefinitely to prevent further damage...")
+			slog.Error("PKCS11 authentication error detected. Further retries may cause the token to be erased.", "cobra_cmd", cmd.Use, "error", err)
+			slog.Warn("Process will now sleep indefinitely to prevent further damage...", "cobra_cmd", cmd.Use)
 			time.Sleep(8760 * time.Hour)
 		}
 
 		if err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).Fatalf("failed to initialize provider: %v", err)
+			logging.Fatal("failed to initialize provider", "cobra_cmd", cmd.Use, "error", err)
 		}
 
 		g := new(errgroup.Group)
@@ -194,7 +194,7 @@ Using AES-CBC with HMAC authentication, using CKA_ID, using CLI flags and servin
 		}
 
 		if err = g.Wait(); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).Error(err)
+			slog.Error("gRPC server error", "cobra_cmd", cmd.Use, "error", err)
 		}
 
 		return
@@ -269,7 +269,7 @@ func initProvider() (p providers.Provider, err error) {
 	config := &crypto11.Config{}
 	switch vprFlgsServe.Provider {
 	case "p11", "softhsm":
-		logrus.Debug("initProvider: case p11 or softhsm")
+		slog.Debug("initProvider: case p11 or softhsm")
 		config = &crypto11.Config{
 			Path:            vprFlgsServe.P11Lib,
 			Pin:             vprFlgsServe.P11Pin,
@@ -277,7 +277,7 @@ func initProvider() (p providers.Provider, err error) {
 		}
 
 	case "luna", "dpod":
-		logrus.Debug("initProvider: case luna HSM or dpod")
+		slog.Debug("initProvider: case luna HSM or dpod")
 		config = &crypto11.Config{
 			Path:            vprFlgsServe.P11Lib,
 			Pin:             vprFlgsServe.P11Pin,
@@ -288,7 +288,7 @@ func initProvider() (p providers.Provider, err error) {
 			},
 		}
 	default:
-		logrus.WithField("provider", vprFlgsServe.Provider).Error("unknown provider")
+		slog.Error("unknown provider", "provider", vprFlgsServe.Provider)
 		err = errors.New("unknown provider")
 		return
 	}
@@ -322,7 +322,7 @@ func initProvider() (p providers.Provider, err error) {
 }
 
 func grpcServe(gl net.Listener, p providers.Provider) (err error) {
-	logrus.Trace("grpcServe")
+	slog.Log(context.Background(), logging.LevelTrace, "grpcServe")
 
 	// Create a gRPC server to host the services
 	serverOptions := []grpc.ServerOption{
@@ -335,12 +335,12 @@ func grpcServe(gl net.Listener, p providers.Provider) (err error) {
 	reflection.Register(gs)
 	istio.RegisterKeyManagementServiceServer(gs, p)
 
-	logrus.Infof("Serving on socket: %s", gl.Addr().String())
-	logrus.Debugf("grpcServe: value of grpcPort user input: %d", vprFlgsServe.Port)
+	slog.Info("serving on socket", "address", gl.Addr().String())
+	slog.Debug("grpc port", "port", vprFlgsServe.Port)
 
 START:
 	if err = gs.Serve(gl); err != nil {
-		logrus.Error(err)
+		slog.Error("gRPC serve error", "error", err)
 		goto START
 	}
 	return
@@ -348,6 +348,6 @@ START:
 
 func unknownServiceHandler(srv interface{}, stream grpc.ServerStream) error {
 	typeOfSrv := reflect.TypeOf(srv)
-	logrus.Infof("unknownServiceHandler. Looking for: %v, %v", typeOfSrv, srv)
+	slog.Info("unknown service handler", "type", typeOfSrv, "service", srv)
 	return nil
 }

--- a/cmd/k8s-kms-plugin/cmd/test.go
+++ b/cmd/k8s-kms-plugin/cmd/test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -25,8 +25,11 @@ import (
 	"path/filepath"
 	"time"
 
+	"context"
+	"log/slog"
+
+	"github.com/ThalesGroup/k8s-kms-plugin/pkg/logging"
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
@@ -104,7 +107,7 @@ var testCmd = &cobra.Command{
 	// Initialize and populate cobra CLI flags values with viper during the Persistent pre-run
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := InitViperSubCmdE(viper.GetViper(), cmd, &viperFlagsTest); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Error("Error initializing Viper")
+			slog.Error("Error initializing Viper", "cobra_cmd", cmd.Use, "error", err)
 			return err
 		}
 		return nil
@@ -125,7 +128,7 @@ var testCmd = &cobra.Command{
 func loopTestRun() error {
 	count := 0
 	for {
-		logrus.Info("Running Tests")
+		slog.Info("Running Tests")
 		_ = runTest()
 		time.Sleep(10 * time.Second)
 		count++
@@ -142,7 +145,7 @@ func runTest() error {
 	ictx, icancel, ic, err := istio.GetClientSocket(viperFlagsTest.SocketPath, viperFlagsTest.Timeout)
 	defer icancel()
 	if err != nil {
-		logrus.Fatal(err)
+		logging.Fatal("socket connection error", "error", err)
 		return err
 	}
 
@@ -168,37 +171,36 @@ func runTest() error {
 	/*
 		GenerateDEK
 	*/
-	logrus.Info("Test 1 GenerateKEK 256 AES")
+	slog.Info("Test 1 GenerateKEK 256 AES")
 	var genKEKResp *istio.GenerateKEKResponse
 	genKEKResp, err = ic.GenerateKEK(ictx, &istio.GenerateKEKRequest{
 		KekKid: kekKid,
 	})
 	if err != nil {
-		logrus.Errorf("Test 1 Failed: %v", err)
+		slog.Error("Test 1 failed", "error", err)
 		return err
 	}
-	logrus.Infof("Test 1 Returned KEK KID: %s", string(genKEKResp.KekKid))
+	slog.Info("Test 1 result", "kek_kid", string(genKEKResp.KekKid))
 	/*
 		GenerateDEK
 	*/
-	logrus.Info("Test 2 GenerateDEK 256 AES")
+	slog.Info("Test 2 GenerateDEK 256 AES")
 	var genDEKResp *istio.GenerateDEKResponse
 	if genDEKResp, err = ic.GenerateDEK(ictx, &istio.GenerateDEKRequest{
 
 		KekKid: genKEKResp.KekKid,
 	}); err != nil {
-		logrus.Fatal(err)
-
+		logging.Fatal("Test 2 failed", "error", err)
 		return err
 	}
 
-	logrus.Infof("Test 2 Returned EncryptedDekBlob: %s", genDEKResp.EncryptedDekBlob)
+	slog.Info("Test 2 result", "encrypted_dek_blob", genDEKResp.EncryptedDekBlob)
 
 	/*
 		GenerateSKey
 	*/
 
-	logrus.Info("Test 3 GenerateSKey 4096 RSA")
+	slog.Info("Test 3 GenerateSKey 4096 RSA")
 	var genSKeyResp *istio.GenerateSKeyResponse
 	if genSKeyResp, err = ic.GenerateSKey(ictx, &istio.GenerateSKeyRequest{
 		Size:             4096,
@@ -206,15 +208,15 @@ func runTest() error {
 		KekKid:           genKEKResp.KekKid,
 		EncryptedDekBlob: genDEKResp.EncryptedDekBlob,
 	}); err != nil {
-		logrus.Fatal(err)
+		logging.Fatal("Test 3 failed", "error", err)
 		return err
 	}
-	logrus.Infof("Test 3 Returned WrappedSKEY: %s", genSKeyResp.EncryptedSkeyBlob)
+	slog.Info("Test 3 result", "encrypted_skey_blob", genSKeyResp.EncryptedSkeyBlob)
 
 	/*
 		LoadSKEY
 	*/
-	logrus.Info("Test 4 LoadSKEY 4096 RSA")
+	slog.Info("Test 4 LoadSKEY 4096 RSA")
 	var loadSKEYResp *istio.LoadSKeyResponse
 	if loadSKEYResp, err = ic.LoadSKey(ictx, &istio.LoadSKeyRequest{
 
@@ -222,11 +224,11 @@ func runTest() error {
 		EncryptedDekBlob:  genDEKResp.EncryptedDekBlob,
 		EncryptedSkeyBlob: genSKeyResp.EncryptedSkeyBlob,
 	}); err != nil {
-		logrus.Fatal(err)
+		logging.Fatal("Test 4 failed", "error", err)
 		return err
 	}
 	var out string
-	if logrus.GetLevel() >= logrus.DebugLevel {
+	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
 		out = string(loadSKEYResp.PlaintextSkey)
 	} else {
 		out = "Success"
@@ -236,11 +238,10 @@ func runTest() error {
 	var b *pem.Block
 	b, _ = pem.Decode(loadSKEYResp.PlaintextSkey)
 	if skey, err = x509.ParsePKCS1PrivateKey(b.Bytes); err != nil {
-		logrus.Fatal(err)
-
+		logging.Fatal("failed to parse PKCS1 private key", "error", err)
 		return err
 	}
-	logrus.Infof("Test 4 Returned LoadedSKey in PEM Format: %v", out)
+	slog.Info("Test 4 result", "skey", out)
 	skey.Public()
 
 	// Generate a dummy istiod intermediate CA CSR from this
@@ -258,7 +259,7 @@ func runTest() error {
 
 	var istioIntermediateCaCSR []byte
 	if istioIntermediateCaCSR, err = x509.CreateCertificateRequest(rand.Reader, csrTemplate, skey); nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("failed to create certificate request", "error", err)
 		return err
 	}
 
@@ -269,11 +270,11 @@ func runTest() error {
 	var aadHashOfSelectedCsrTemplateFields []byte
 	aadHashOfSelectedCsrTemplateFields, err = hashCsrTemplate(sha256.New(), csrTemplate)
 	if nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("failed to hash CSR template", "error", err)
 		return err
 	}
 
-	logrus.Info("Test 5 AuthenticatedEncrypt ")
+	slog.Info("Test 5 AuthenticatedEncrypt ")
 	var aeResp *istio.AuthenticatedEncryptResponse
 	if aeResp, err = ic.AuthenticatedEncrypt(ictx, &istio.AuthenticatedEncryptRequest{
 		KekKid:           genKEKResp.KekKid,
@@ -281,14 +282,14 @@ func runTest() error {
 		Plaintext:        istioIntermediateCaCSR,
 		Aad:              aadHashOfSelectedCsrTemplateFields,
 	}); err != nil {
-		logrus.Fatal(err)
+		logging.Fatal("Test 5 failed", "error", err)
 		return err
 	}
 
 	/*
 		AuthenticatedDecrypt
 	*/
-	logrus.Info("Test 6 AuthenticatedDecrypt ")
+	slog.Info("Test 6 AuthenticatedDecrypt ")
 	var adResp *istio.AuthenticatedDecryptResponse
 	if adResp, err = ic.AuthenticatedDecrypt(ictx, &istio.AuthenticatedDecryptRequest{
 		KekKid:           genKEKResp.KekKid,
@@ -296,33 +297,33 @@ func runTest() error {
 		Ciphertext:       aeResp.Ciphertext,
 		Aad:              aadHashOfSelectedCsrTemplateFields,
 	}); err != nil {
-		logrus.Fatal(err)
+		logging.Fatal("Test 6 failed", "error", err)
 		return err
 	}
-	logrus.Infof("Test 6 Returned AuthenticatedDecrypt (b64): %s", base64.URLEncoding.EncodeToString(adResp.Plaintext))
+	slog.Info("Test 6 result", "authenticated_decrypt_b64", base64.URLEncoding.EncodeToString(adResp.Plaintext))
 
-	logrus.Info("Test 7 ImportCACert ")
+	slog.Info("Test 7 ImportCACert ")
 
 	var icResp *istio.ImportCACertResponse
 	if icResp, err = ic.ImportCACert(ictx, &istio.ImportCACertRequest{
 		CaId:       caKid,
 		CaCertBlob: []byte(dummyCaCert),
 	}); err != nil {
-		logrus.Fatal(err)
+		logging.Fatal("Test 7 failed", "error", err)
 		return err
 	}
 
-	logrus.Infof("Test 7 Returned ImportCACert: %v", icResp.Success)
+	slog.Info("Test 7 result", "success", icResp.Success)
 
 	/*
 	   VerifyCertChain - take the CA-signed cert and hand over to verify the chain (chain not provided - currently assumes there's no intermediate and we only need the CA cert in the HSM to verify)
 	*/
-	logrus.Info("Test 8 VerifyCertChain (only target cert)")
+	slog.Info("Test 8 VerifyCertChain (only target cert)")
 
 	var signedCert []byte
 	signedCert, err = dummyCaCertSigner(adResp.Plaintext, dummyCaCert, dummyCaPrivKey)
 	if nil != err {
-		logrus.Fatalf("error signing cert by dummy CA")
+		logging.Fatal("error signing cert by dummy CA", "error", err)
 		return err
 	}
 
@@ -334,12 +335,12 @@ func runTest() error {
 	}
 	var verifyCertChainResp = &istio.VerifyCertChainResponse{}
 	if verifyCertChainResp, err = ic.VerifyCertChain(ictx, verifyCertChainReq); nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("Test 8 failed", "error", err)
 		return err
 	}
 
 	if !verifyCertChainResp.SuccessfulVerification {
-		logrus.Fatal("VerifyCertChain returned false")
+		logging.Fatal("VerifyCertChain returned false")
 		return fmt.Errorf("VerifyCertChain returned false")
 	}
 
@@ -347,7 +348,7 @@ func runTest() error {
 	   VerifyCertChain - provides the target cert and the root cert (which matches one already in the HSM)
 	*/
 
-	logrus.Info("Test 9 VerifyCertChain (target cert and root cert - check that root cert matches one in the HSM)")
+	slog.Info("Test 9 VerifyCertChain (target cert and root cert - check that root cert matches one in the HSM)")
 	chain = nil
 	chain = make([][]byte, 0)
 	// Append the root cert first
@@ -358,12 +359,12 @@ func runTest() error {
 	verifyCertChainReq.Certificates = chain
 
 	if verifyCertChainResp, err = ic.VerifyCertChain(ictx, verifyCertChainReq); nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("Test 9 failed", "error", err)
 		return err
 	}
 
 	if !verifyCertChainResp.SuccessfulVerification {
-		logrus.Fatal("VerifyCertChain returned false")
+		logging.Fatal("VerifyCertChain returned false")
 		return fmt.Errorf("VerifyCertChain returned false")
 	}
 
@@ -371,7 +372,7 @@ func runTest() error {
 	   VerifyCertChain - provides the target cert and an intermediate cert (which verifies against one already in the HSM)
 	*/
 
-	logrus.Info("Test 10 VerifyCertChain (target cert and intermediate cert)")
+	slog.Info("Test 10 VerifyCertChain (target cert and intermediate cert)")
 
 	var intermediateForSigningPrivKey *rsa.PrivateKey
 	intermediateForSigningPrivKey, err = rsa.GenerateKey(rand.Reader, 4096)
@@ -390,7 +391,7 @@ func runTest() error {
 
 	var istioIntermediateCaCSRForEnd []byte
 	if istioIntermediateCaCSRForEnd, err = x509.CreateCertificateRequest(rand.Reader, csrIntermediateTemplateForSigning, intermediateForSigningPrivKey); nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("failed to create intermediate certificate request", "error", err)
 		return err
 	}
 
@@ -408,12 +409,12 @@ func runTest() error {
 	verifyCertChainReq.Certificates = chain
 
 	if verifyCertChainResp, err = ic.VerifyCertChain(ictx, verifyCertChainReq); nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("Test 10 failed", "error", err)
 		return err
 	}
 
 	if !verifyCertChainResp.SuccessfulVerification {
-		logrus.Fatal("VerifyCertChain returned false")
+		logging.Fatal("VerifyCertChain returned false")
 		return fmt.Errorf("VerifyCertChain returned false")
 	}
 
@@ -422,7 +423,7 @@ func runTest() error {
 	   We corrupt the signature
 	*/
 
-	logrus.Info("Test 11 VerifyCertChain (only target cert - negative)")
+	slog.Info("Test 11 VerifyCertChain (only target cert - negative)")
 
 	badCert, _ := x509.ParseCertificate(signedCert)
 	badCert.Signature[42] ^= badCert.Signature[42]
@@ -444,7 +445,7 @@ func runTest() error {
 	   but the provided chain verifies)
 	*/
 
-	logrus.Info("Test 12 VerifyCertChain (target cert and root cert - negative - root cert does not match loaded)")
+	slog.Info("Test 12 VerifyCertChain (target cert and root cert - negative - root cert does not match loaded)")
 
 	chain = nil
 	chain = make([][]byte, 0)
@@ -455,7 +456,7 @@ func runTest() error {
 	var signedCertByBadCa []byte
 	signedCertByBadCa, err = dummyCaCertSigner(adResp.Plaintext, dummyBadCaCert, dummyBadCaPrivKey)
 	if nil != err {
-		logrus.Fatalf("%v", err.Error())
+		logging.Fatal("failed to sign cert by bad CA", "error", err)
 		return err
 	}
 
@@ -491,7 +492,7 @@ func dummyCaCertSigner(p10Csr []byte, pemCaCert, pemCaPrivKey string) (signedCer
 	var reloadedCsr *x509.CertificateRequest
 	reloadedCsr, err = x509.ParseCertificateRequest(p10Csr)
 	if nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("failed to parse certificate request", "error", err)
 		return
 	}
 
@@ -500,7 +501,7 @@ func dummyCaCertSigner(p10Csr []byte, pemCaCert, pemCaPrivKey string) (signedCer
 	var parsedRootCaCert *x509.Certificate
 	parsedRootCaCert, err = x509.ParseCertificate(pemCaCertBlock.Bytes)
 	if nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("failed to parse CA certificate", "error", err)
 		return
 	}
 
@@ -509,20 +510,20 @@ func dummyCaCertSigner(p10Csr []byte, pemCaCert, pemCaPrivKey string) (signedCer
 	var parsedCaPrivKey *rsa.PrivateKey
 	parsedCaPrivKey, err = x509.ParsePKCS1PrivateKey(pemKeyBlock.Bytes)
 	if nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("failed to parse CA private key", "error", err)
 		return
 	}
 
 	// Sanity check
-	if nil != reloadedCsr.CheckSignature() {
-		logrus.Fatal(err)
+	if sigErr := reloadedCsr.CheckSignature(); sigErr != nil {
+		logging.Fatal("CSR signature check failed", "error", sigErr)
 		return
 	}
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		logrus.Fatalf("Failed to generate serial number: %v", err)
+		logging.Fatal("failed to generate serial number", "error", err)
 	}
 
 	var childTemplate = &x509.Certificate{
@@ -552,14 +553,14 @@ func dummyCaCertSigner(p10Csr []byte, pemCaCert, pemCaPrivKey string) (signedCer
 
 	signedCert, err = x509.CreateCertificate(rand.Reader, childTemplate, parsedRootCaCert, reloadedCsr.PublicKey, parsedCaPrivKey)
 	if nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("failed to create certificate", "error", err)
 		return
 	}
 
 	var loadedSignedCert = &x509.Certificate{}
 	loadedSignedCert, err = x509.ParseCertificate(signedCert)
 	if nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("failed to parse signed certificate", "error", err)
 		return
 	}
 
@@ -568,7 +569,7 @@ func dummyCaCertSigner(p10Csr []byte, pemCaCert, pemCaPrivKey string) (signedCer
 	certPool.AddCert(parsedRootCaCert)
 	_, err = loadedSignedCert.Verify(x509.VerifyOptions{Roots: certPool})
 	if nil != err {
-		logrus.Fatal(err)
+		logging.Fatal("certificate verification failed", "error", err)
 		return
 	}
 

--- a/cmd/k8s-kms-plugin/cmd/verify-cert.go
+++ b/cmd/k8s-kms-plugin/cmd/verify-cert.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -17,7 +17,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"log/slog"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -46,7 +47,7 @@ var verifyCertCmd = &cobra.Command{
 	// Initialize and populate cobra CLI flags values with viper during the Persistent pre-run
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := InitViperSubCmdE(viper.GetViper(), cmd, &vprFlgsVerifyCert); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Error("Error initializing Viper")
+			slog.Error("Error initializing Viper", "cobra_cmd", cmd.Use, "error", err)
 			return err
 		}
 		return nil

--- a/cmd/k8s-kms-plugin/cmd/version.go
+++ b/cmd/k8s-kms-plugin/cmd/version.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -11,9 +11,9 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 
 	version "github.com/ThalesGroup/k8s-kms-plugin/pkg/version"
-	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -48,7 +48,7 @@ Examples:
 	// Initialize and populate cobra CLI flags values with viper during the Persistent pre-run
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := InitViperSubCmdE(viper.GetViper(), cmd, &vprFlgsVersion); err != nil {
-			logrus.WithField("cobra-cmd", cmd.Use).WithError(err).Error("Error initializing Viper")
+			slog.Error("Error initializing Viper", "cobra_cmd", cmd.Use, "error", err)
 			return err
 		}
 		return nil

--- a/cmd/k8s-kms-plugin/cmd/viper-patch-sub.go
+++ b/cmd/k8s-kms-plugin/cmd/viper-patch-sub.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -15,9 +15,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
+	"context"
+	"log/slog"
 
-	"github.com/sirupsen/logrus"
+	"github.com/ThalesGroup/k8s-kms-plugin/pkg/logging"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -60,7 +62,7 @@ import (
 func UnmarshalSubMergedE(v *viper.Viper, section string, target any) error {
 	// 1. Skip if no config file is loaded at all
 	if v.ConfigFileUsed() == "" {
-		logrus.Trace("UnmarshalSubMerged: no config file loaded")
+		slog.Log(context.Background(), logging.LevelTrace, "UnmarshalSubMerged: no config file loaded")
 		return v.Unmarshal(target) // only env, flags, defaults
 	}
 
@@ -68,13 +70,13 @@ func UnmarshalSubMergedE(v *viper.Viper, section string, target any) error {
 	sub := v.GetStringMap(section)
 	if len(sub) == 0 {
 		// No subsection found, fallback to flags/env/default
-		logrus.Tracef("UnmarshalSubMerged: no config found for section '%s'", section)
+		slog.Log(context.Background(), logging.LevelTrace, "UnmarshalSubMerged: no config found for section", "section", section)
 		return v.Unmarshal(target)
 	}
 
 	// 3. Merge section into Viper's config layer (not override!)
 	if err := v.MergeConfigMap(sub); err != nil {
-		logrus.WithError(err).Errorf("UnmarshalSubMerged: failed to merge config section '%s'", section)
+		slog.Error("UnmarshalSubMerged: failed to merge config section", "section", section, "error", err)
 		return fmt.Errorf("failed to merge config section '%s': %w", section, err)
 	}
 
@@ -101,18 +103,18 @@ func UnmarshalSubMergedE(v *viper.Viper, section string, target any) error {
 func InitViperSubCmdE(v *viper.Viper, cobraCmd *cobra.Command, target any) error {
 	// the name of the cobra subcommand is the "section" of the config file
 	// in this situation we suppose the cobra command correspond to a first level command. But if it is a second or third or greater level subcommand, we need the section to represent all the parent name. How can we get the fulle path to root command ?
-	logrus.WithField("cobra-cmd", cobraCmd.Use).Trace("cobra command path: " + cobraCmd.CommandPath())
+	slog.Log(context.Background(), logging.LevelTrace, "cobra command path", "path", cobraCmd.CommandPath(), "cobra_cmd", cobraCmd.Use)
 
 	// cobra.CommandPath returns the full path to the command, including all parent commands, each command separated by 1 space.
 	// TODO: allow cobra.CommandPath to get new separator like ".".
 	// See https://github.com/spf13/cobra/blob/40b5bc1437a564fc795d388b23835e84f54cd1d1/command.go#L1460
 	sectionPath := strings.ReplaceAll(cobraCmd.CommandPath(), " ", ".")
-	logrus.WithField("cobra-cmd", cobraCmd.Use).Tracef("section path: %s", sectionPath)
+	slog.Log(context.Background(), logging.LevelTrace, "section path", "section_path", sectionPath, "cobra_cmd", cobraCmd.Use)
 
 	// modify viper env prefix with the current cobra subcommand name
 	sectionEnvPrefix := strings.ToUpper(strings.NewReplacer("-", "_", ".", "_").Replace(sectionPath)) // for the env prefix, this should be uppercase snake case and replace dot . with underscore
 	// concat the previous viper env prefix with the current cobra subcommand name
-	logrus.WithField("cobra-cmd", cobraCmd.Use).Trace("new viper env prefix: " + sectionEnvPrefix)
+	slog.Log(context.Background(), logging.LevelTrace, "new viper env prefix", "env_prefix", sectionEnvPrefix, "cobra_cmd", cobraCmd.Use)
 	v.SetEnvPrefix(sectionEnvPrefix)
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_")) // Converts flags to ENV format
 	v.AutomaticEnv()                                   // Enables automatic binding
@@ -120,14 +122,14 @@ func InitViperSubCmdE(v *viper.Viper, cobraCmd *cobra.Command, target any) error
 	// Bind subcommand-specific cobra flags to viper
 	err := v.BindPFlags(cobraCmd.Flags())
 	if err != nil {
-		logrus.WithField("cobra-cmd", cobraCmd.Use).Errorf("error binding flags: %v", err)
+		slog.Error("error binding flags", "cobra_cmd", cobraCmd.Use, "error", err)
 		return fmt.Errorf("error binding flags: %w", err)
 	}
 
 	// Load config values for this subcommand
 	err = UnmarshalSubMergedE(v, sectionPath, &target)
 	if err != nil {
-		logrus.WithField("cobra-cmd", cobraCmd.Use).Fatalf("failed to unmarshal version config: %v", err)
+		slog.Error("failed to unmarshal version config", "cobra_cmd", cobraCmd.Use, "error", err)
 		return fmt.Errorf("failed to unmarshal version config: %w", err)
 	}
 
@@ -163,13 +165,13 @@ func InitViperSubCmdE(v *viper.Viper, cobraCmd *cobra.Command, target any) error
 func ReadViperConfigE(v *viper.Viper, cmd *cobra.Command) error {
 	// use a configuration file parsed by viper
 	if cmd.Flags().Lookup("config").Changed && cfgFile != "" {
-		logrus.Tracef("Case config file from the flag: %s", cfgFile)
+		slog.Log(context.Background(), logging.LevelTrace, "case config file from the flag", "config_file", cfgFile)
 		viper.SetConfigFile(cfgFile)
 	} else if envVar, ok := os.LookupEnv("K8S_KMS_PLUGIN_CONFIG"); ok {
-		logrus.Tracef("Case config file from the environment variable: %s", envVar)
+		slog.Log(context.Background(), logging.LevelTrace, "case config file from env var", "config_file", envVar)
 		viper.SetConfigFile(envVar)
 	} else {
-		logrus.Tracef("Case config file from default location")
+		slog.Log(context.Background(), logging.LevelTrace, "Case config file from default location")
 		// Find home directory.
 		home, err := homedir.Dir()
 		if err != nil {
@@ -178,17 +180,16 @@ func ReadViperConfigE(v *viper.Viper, cmd *cobra.Command) error {
 
 		viper.SetConfigName("k8s-kms-plugin.conf") // name of config file (viper needs no file extension)
 		// TODO: consider using the rootCmd.Flags().Lookup("config").DefValue for viper.SetConfigName
-		// logrus.Infof("default config filename %s", rootCmd.Flags().Lookup("config").DefValue)
-		logrus.Tracef("Search config in .config directory %s with name k8s-kms-plugin.conf.yaml (without extension).", home)
+		slog.Log(context.Background(), logging.LevelTrace, "searching config in home directory", "dir", home)
 		viper.AddConfigPath(home)
-		logrus.Tracef("Search config in home directory %s with name k8s-kms-plugin.conf.yaml (without extension).", filepath.Join(home, ".config/k8s-kms-plugin"))
+		slog.Log(context.Background(), logging.LevelTrace, "searching config in .config directory", "dir", filepath.Join(home, ".config/k8s-kms-plugin"))
 		viper.AddConfigPath(filepath.Join(home, ".config/k8s-kms-plugin"))
 	}
 
 	// If a config file is not found, log a trace error. Otherwise, read it in.
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			logrus.Trace("No config file found; continue with cobra default values")
+			slog.Log(context.Background(), logging.LevelTrace, "No config file found; continue with cobra default values")
 		} else {
 			// Config file was found but another error occurred
 			return fmt.Errorf("error reading config file: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,9 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/infobloxopen/atlas-app-toolkit v1.4.1
-	github.com/keepeye/logrus-filename v0.0.0-20190711075016-ce01a4391dd1
 	github.com/miekg/pkcs11 v1.1.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/protoc-gen-go-json v1.1.0
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -46,12 +44,14 @@ require (
 	github.com/ThalesGroup/crypto11 v1.5.0
 	github.com/ThalesGroup/gose v0.11.0-rc
 	github.com/hashicorp/go-version v1.7.0
+	github.com/lmittmann/tint v1.1.3
 	k8s.io/kms v0.34.1
 )
 
 require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,6 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/keepeye/logrus-filename v0.0.0-20190711075016-ce01a4391dd1 h1:JL2rWnBX8jnbHHlLcLde3BBWs+jzqZvOmF+M3sXoNOE=
-github.com/keepeye/logrus-filename v0.0.0-20190711075016-ce01a4391dd1/go.mod h1:nNLjpEi4xVFB7358xLPpPscdvXP+pbhiHgSmjIur8z0=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -187,6 +185,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.1-0.20200116171513-9eb3fc897d6f/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lmittmann/tint v1.1.3 h1:Hv4EaHWXQr+GTFnOU4VKf8UvAtZgn0VuKT+G0wFlO3I=
+github.com/lmittmann/tint v1.1.3/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Thales Group
+ * SPDX-License-Identifier: MIT
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+)
+
+// LevelTrace is a custom slog level below Debug, following the convention of slog.Level(-8).
+const LevelTrace = slog.Level(-8)
+
+// LevelQuiet suppresses all log output when used with a DiscardHandler.
+// It is not passed to a handler's minimum level; instead root.go detects it
+// and installs slog.DiscardHandler directly.
+const LevelQuiet = slog.Level(math.MaxInt)
+
+// ParseLevel converts a level name string to a slog.Level.
+// Accepted values: trace, debug, info, warn, error, quiet.
+func ParseLevel(s string) (slog.Level, error) {
+	switch s {
+	case "trace":
+		return LevelTrace, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	case "quiet":
+		return LevelQuiet, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unknown log level %q, accepted: trace, debug, info, warn, error, quiet", s)
+	}
+}
+
+// Fatal logs an error message with optional key-value pairs and exits with status 1.
+func Fatal(msg string, args ...any) {
+	slog.Error(msg, args...)
+	os.Exit(1)
+}

--- a/pkg/providers/istio.go
+++ b/pkg/providers/istio.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -25,8 +25,7 @@ import (
 	"github.com/ThalesGroup/k8s-kms-plugin/apis/istio/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/sirupsen/logrus"
+	"log/slog"
 )
 
 var (
@@ -173,7 +172,6 @@ func generateSKey(ctx *crypto11.Context, request *istio.GenerateSKeyRequest, dek
 // GenerateDEK a 256 bit AES DEK Key , Wrapped via JWE with the PKCS11 base KEK
 func (p *P11) GenerateDEK(ctx context.Context, request *istio.GenerateDEKRequest) (resp *istio.GenerateDEKResponse, err error) {
 	if request == nil {
-		logrus.Error(err)
 		return nil, status.Error(codes.InvalidArgument, "no request sent")
 	}
 	var encryptor gose.JweEncryptor
@@ -186,7 +184,7 @@ func (p *P11) GenerateDEK(ctx context.Context, request *istio.GenerateDEKRequest
 
 	// GenerateDEK from p11.go
 	if dekBlob, err = GenerateDEK(p.ctx, encryptor); err != nil {
-		logrus.Error(err)
+		slog.Error("GenerateDEK failed", "error", err)
 		return
 	}
 	resp = &istio.GenerateDEKResponse{
@@ -200,7 +198,7 @@ func (p *P11) GenerateKEK(ctx context.Context, request *istio.GenerateKEKRequest
 	if request.KekKid == nil {
 		request.KekKid, err = p.genKekKid()
 		if err != nil {
-			logrus.Error(err)
+			slog.Error("genKekKid failed", "error", err)
 			return
 		}
 	}
@@ -208,7 +206,7 @@ func (p *P11) GenerateKEK(ctx context.Context, request *istio.GenerateKEKRequest
 	// GenerateKEK from p11.go
 	_, err = GenerateKEK(p.ctx, request.KekKid, []byte(defaultKEKlabel), jose.AlgA256GCM)
 	if err != nil {
-		logrus.Error(err)
+		slog.Error("GenerateKEK failed", "error", err)
 		return
 	}
 	resp = &istio.GenerateKEKResponse{
@@ -328,7 +326,7 @@ func (p *P11) LoadSKey(ctx context.Context, request *istio.LoadSKeyRequest) (res
 func (p *P11) VerifyCertChain(ctx context.Context, request *istio.VerifyCertChainRequest) (resp *istio.VerifyCertChainResponse, err error) {
 	defer func() {
 		if err != nil {
-			logrus.Errorf("Error in VerifyCertChain: %v", err)
+			slog.Error("VerifyCertChain error", "error", err)
 		}
 	}()
 	if nil == request {
@@ -408,7 +406,7 @@ func (p *P11) VerifyCertChain(ctx context.Context, request *istio.VerifyCertChai
 
 				var parsedAdditionalIntermediateCert *x509.Certificate
 				if parsedAdditionalIntermediateCert, err = x509.ParseCertificate(request.Certificates[i]); nil != err {
-					logrus.Errorf("failed to parse additional intermediate certificate")
+					slog.Error("failed to parse additional intermediate certificate")
 					return
 				}
 				preliminaryVerifyOpts.Intermediates.AddCert(parsedAdditionalIntermediateCert)
@@ -416,7 +414,7 @@ func (p *P11) VerifyCertChain(ctx context.Context, request *istio.VerifyCertChai
 
 			var parsedChains [][]*x509.Certificate
 			if parsedChains, err = parsedTargetCert.Verify(preliminaryVerifyOpts); nil != err {
-				logrus.Errorf("supplied chain does not verify")
+				slog.Error("supplied chain does not verify")
 				return
 			} else {
 
@@ -460,7 +458,7 @@ func (p *P11) VerifyCertChain(ctx context.Context, request *istio.VerifyCertChai
 
 				var parsedAdditionalIntermediateCert *x509.Certificate
 				if parsedAdditionalIntermediateCert, err = x509.ParseCertificate(request.Certificates[i]); nil != err {
-					logrus.Errorf("failed to parse additional intermediate certificate")
+					slog.Error("failed to parse additional intermediate certificate")
 					return
 				}
 				verifyOpts.Intermediates.AddCert(parsedAdditionalIntermediateCert)

--- a/pkg/providers/p11.go
+++ b/pkg/providers/p11.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Thales Group
+ * Copyright 2026 Thales Group
  * SPDX-License-Identifier: MIT
  *
  * Use of this source code is governed by an MIT-style
@@ -20,15 +20,16 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"log/slog"
 
 	"github.com/ThalesGroup/crypto11"
 	"github.com/ThalesGroup/gose"
 	"github.com/ThalesGroup/gose/hsm"
 	"github.com/ThalesGroup/gose/jose"
 
+	"github.com/ThalesGroup/k8s-kms-plugin/pkg/logging"
 	"github.com/google/uuid"
 	"github.com/miekg/pkcs11"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -67,7 +68,7 @@ func GenerateDEK(ctx11 *crypto11.Context, encryptor gose.JweEncryptor) (encrypte
 
 	var rng io.Reader
 	if rng, err = ctx11.NewRandomReader(); err != nil {
-		logrus.Error(err)
+		slog.Error("NewRandomReader failed", "error", err)
 		return
 	}
 
@@ -81,13 +82,13 @@ func GenerateDEK(ctx11 *crypto11.Context, encryptor gose.JweEncryptor) (encrypte
 	}
 	var dekStr []byte
 	if dekStr, err = json.Marshal(dekJWK); err != nil {
-		logrus.WithError(err).Error("generateDEK: failed to marshal DEK JWK")
+		slog.Error("generateDEK: failed to marshal DEK JWK", "error", err)
 		return
 	}
 	// using the AES key as it's payload
 	var encryptedString string
 	if encryptedString, err = encryptor.Encrypt(dekStr, nil); err != nil {
-		logrus.Error(err)
+		slog.Error("encrypt DEK failed", "error", err)
 		return
 	}
 	encryptedKeyBlob = []byte(encryptedString)
@@ -235,14 +236,14 @@ func NewP11(
 
 	// Bootstrap the active Pkcs11 device or die
 	if p.ctx, err = crypto11.Configure(p.config); err != nil {
-		logrus.WithError(err).Error("NewP11: failed to configure the active Pkcs11 device")
+		slog.Error("NewP11: failed to configure the active Pkcs11 device", "error", err)
 		return
 	}
 
 	// Bootstrap the key rotation Pkcs11 device or die
 	if isKeyRotation {
 		if p.oldCtx, err = crypto11.Configure(p.oldConfig); err != nil {
-			logrus.WithError(err).Error("NewP11: failed to configure the key rotation Pkcs11 device")
+			slog.Error("NewP11: failed to configure the key rotation Pkcs11 device", "error", err)
 			return
 		}
 	}
@@ -280,7 +281,7 @@ func NewP11(
 				p.oldHmacCkaLabel = oldHmacKeyLabel
 
 				if p.oldHmacCkaId, err = FindCkaAttrByIdOrLabel(p.oldCtx, p.oldAlgorithm, crypto11.CkaId, nil, []byte(p.oldHmacCkaLabel)); err != nil {
-					logrus.WithError(err).Error("NewP11: failed to find HMAC CKA_ID by label")
+					slog.Error("NewP11: failed to find HMAC CKA_ID by label", "error", err)
 					return nil, err
 				}
 
@@ -289,40 +290,40 @@ func NewP11(
 
 				var labelBuf []byte
 				if labelBuf, err = FindCkaAttrByIdOrLabel(p.oldCtx, p.oldAlgorithm, crypto11.CkaLabel, p.oldHmacCkaId, nil); err != nil {
-					logrus.WithError(err).Error("NewP11: failed to find old HMAC CKA_LABEL by ID")
+					slog.Error("NewP11: failed to find old HMAC CKA_LABEL by ID", "error", err)
 					return nil, err
 				}
 
 				p.oldHmacCkaLabel = string(labelBuf)
 
 			} else if oldHmacCkaId == "" && oldHmacKeyLabel == "" {
-				logrus.WithError(err).Errorf("NewP11: oldHmacCkaId and oldHmacKeyLabel are both empty, please provide one of them")
+				slog.Error("NewP11: oldHmacCkaId and oldHmacKeyLabel are both empty, please provide one of them", "error", err)
 				return nil, fmt.Errorf("NewP11: oldHmacCkaId and oldHmacKeyLabel are both empty, please provide one of them")
 			} else {
-				logrus.WithError(err).Errorf("NewP11: both oldHmacCkaId and oldHmacKeyLabel are provided, please provide only one")
+				slog.Error("NewP11: both oldHmacCkaId and oldHmacKeyLabel are provided, please provide only one", "error", err)
 				return nil, fmt.Errorf("NewP11: both oldHmacCkaId and oldHmacKeyLabel are provided, please provide only one")
 			}
 		}
 
 		// find old KEK ID with LABEL
 		if oldKekkeyid == "" && oldKekCkaLabel != "" {
-			logrus.Tracef("NewP11: kek key id (CKA_ID) is empty. Find CKA_ID by CKA_LABEL %s", k8sKekLabel)
+			slog.Log(context.Background(), logging.LevelTrace, "NewP11: finding CKA_ID by CKA_LABEL", "key_label", k8sKekLabel)
 			p.oldKekCkaLabel = oldKekCkaLabel
 
 			if p.oldKekCkaId, err = FindCkaAttrByIdOrLabel(p.oldCtx, p.oldAlgorithm, crypto11.CkaId, nil, []byte(p.oldKekCkaLabel)); err != nil {
-				logrus.WithError(err).Error("NewP11: failed to find OLD KEK CKA_ID by label")
+				slog.Error("NewP11: failed to find OLD KEK CKA_ID by label", "error", err)
 				return nil, err
 			}
 		}
 
 		// find old KEK label with ID
 		if oldKekkeyid != "" && oldKekCkaLabel == "" {
-			logrus.Tracef("NewP11: k8sKekLabel (CKA_LABEL) is empty but kekkeyid (CKA_ID) is not empty. Find CKA_LABEL by CKA_ID %s", oldKekkeyid)
+			slog.Log(context.Background(), logging.LevelTrace, "NewP11: finding CKA_LABEL by CKA_ID", "key_id", oldKekkeyid)
 			p.SetOldKekKeyIdString(oldKekkeyid)
 
 			var labelBuf []byte
 			if labelBuf, err = FindCkaAttrByIdOrLabel(p.oldCtx, p.oldAlgorithm, crypto11.CkaLabel, p.oldKekCkaId, nil); err != nil {
-				logrus.WithError(err).Error("NewP11: failed to find OLD KEK CKA_LABEL by CKA_ID")
+				slog.Error("NewP11: failed to find OLD KEK CKA_LABEL by CKA_ID", "error", err)
 				return nil, err
 			}
 			p.oldKekCkaLabel = string(labelBuf)
@@ -494,10 +495,7 @@ func (p *P11) loadKEKbyID(ctx *crypto11.Context, kekId, kekLabel []byte) (encryp
 	}
 	if handle == nil {
 		err = errors.New("no such key")
-		logrus.WithError(err).WithFields(logrus.Fields{
-			"kekIdentity": string(kekId),
-			"label":       string(kekLabel),
-		}).Error("load KEK by ID or label failed")
+		slog.Error("load KEK by ID or label failed", "error", err, "kekIdentity", string(kekId), "label", string(kekLabel))
 		return
 	}
 	var aead cipher.AEAD
@@ -577,14 +575,14 @@ func (p *P11) Decrypt(ctx context.Context, req *k8skmsv2.DecryptRequest) (resp *
 	case hex.EncodeToString(p.oldKekCkaId):
 		isRotation = true
 	default:
-		logrus.WithError(err).WithField("key_id", req.GetKeyId()).Error("Decrypt: unknown key ID")
+		slog.Error("Decrypt: unknown key ID", "key_id", req.GetKeyId())
 		return nil, fmt.Errorf("Decrypt: unknown key ID: %s", req.GetKeyId())
 	}
 
 	// decrypt with PKCS#11 context
 	out, err = p.decryptWithContext(req, isRotation)
 	if err != nil {
-		logrus.WithError(err).Error("error while decrypting with old key")
+		slog.Error("error while decrypting with old key", "error", err)
 		return nil, err
 	}
 
@@ -628,53 +626,53 @@ func (p *P11) decryptWithContext(req *k8skmsv2.DecryptRequest, isRotation bool) 
 		// Random source from the HSM (pkcs11 context)
 		var rng io.Reader
 		if rng, err = actualCtx.NewRandomReader(); err != nil {
-			logrus.WithError(err).Error("error while creating random reader")
+			slog.Error("error while creating random reader", "error", err)
 			return nil, err
 		}
 
 		// convert the string DecryptRequest.KeyId containing a hex representation as string to hex []byte
 		var reqKekKeyIdByteA []byte
 		if reqKekKeyIdByteA, err = hex.DecodeString(req.GetKeyId()); err != nil {
-			logrus.WithError(err).WithField("DecryptRequest.KeyId", req.GetKeyId()).Error("error while decoding the key id")
+			slog.Error("error while decoding the key id", "error", err, "key_id", req.GetKeyId())
 			return nil, fmt.Errorf("error while decoding the key id: %v", err)
 		}
 
 		switch actualAlgo {
 		case jose.AlgA256GCM:
-			logrus.Tracef("p11:Decrypt case %s", jose.AlgA256GCM)
+			slog.Log(context.Background(), logging.LevelTrace, "p11 Decrypt case", "algorithm", string(jose.AlgA256GCM))
 
 			// get kek by CKA_ID
 			var kek *crypto11.SecretKey
 
 			// Since the DecryptRequest comes from kubernetes, the only information k8s has is the keyId via the StatusResponse
 			if kek, err = actualCtx.FindKey(reqKekKeyIdByteA, nil); nil != err {
-				logrus.WithError(err).WithField("DecryptRequest.KeyId", req.GetKeyId()).Error("error while finding key by CKA_ID")
+				slog.Error("error while finding key by CKA_ID", "error", err, "DecryptRequest.KeyId", req.GetKeyId())
 				return nil, err
 			}
 
 			var aek gose.AeadEncryptionKey
 			if aek, err = p.makeAeadKey(rng, kek); err != nil {
-				logrus.WithError(err).Error("error while creating aead key")
+				slog.Error("error while creating aead key", "error", err)
 				return nil, err
 			}
 			decryptor = gose.NewJweDirectDecryptorAeadImpl([]gose.AeadEncryptionKey{aek})
 
 			if out, aad, err = decryptor.Decrypt(string(req.GetCiphertext())); err != nil {
-				logrus.WithError(err).Error("error during decryption")
+				slog.Error("error during decryption", "error", err)
 				return nil, err
 			}
 			if nil != aad {
 				// AAD should be nil - if not, needs to be changed in tandem with /Encrypt
 				err = fmt.Errorf("bad AAD")
-				logrus.WithError(err).Error("error during decryption AAD should be nil")
+				slog.Error("error during decryption AAD should be nil", "error", err)
 				return nil, err
 			}
 		case jose.AlgA256CBC:
-			logrus.Tracef("p11:Decrypt case %s", jose.AlgA256CBC)
+			slog.Log(context.Background(), logging.LevelTrace, "p11 Decrypt case", "algorithm", string(jose.AlgA256CBC))
 			// get kek by id
 			var kek *crypto11.SecretKey
 			if kek, err = actualCtx.FindKey(reqKekKeyIdByteA, nil); nil != err {
-				logrus.WithError(err).Error("error finding key by ID")
+				slog.Error("error finding key by ID", "error", err)
 				return nil, err
 			}
 
@@ -706,33 +704,33 @@ func (p *P11) decryptWithContext(req *k8skmsv2.DecryptRequest, isRotation bool) 
 			defer blockMode.Close()
 
 			if out, aad, err = decryptor.Decrypt(string(req.GetCiphertext())); err != nil {
-				logrus.WithError(err).Tracef("error during decryption")
+				slog.Log(context.Background(), logging.LevelTrace, "error during decryption", "error", err)
 				return nil, err
 			}
 			if nil != aad {
 				// AAD should be nil - if not, needs to be changed in tandem with /Encrypt
 				err = fmt.Errorf("bad AAD")
-				logrus.WithError(err).Error("error during decryption AAD should be nil")
+				slog.Error("error during decryption AAD should be nil", "error", err)
 				return nil, err
 			}
 		case jose.AlgRSAOAEP:
-			logrus.Tracef("p11:Decrypt case %s", jose.AlgRSAOAEP)
+			slog.Log(context.Background(), logging.LevelTrace, "p11 Decrypt case", "algorithm", string(jose.AlgRSAOAEP))
 			// load pkcs11 context
 			var rsaKeyPair crypto11.SignerDecrypter
 			if rsaKeyPair, err = actualCtx.FindRSAKeyPair(reqKekKeyIdByteA, nil); err != nil {
-				logrus.WithError(err).Errorf("error finding RSA key pair with id %X", reqKekKeyIdByteA)
+				slog.Error("error finding RSA key pair", "key_id", hex.EncodeToString(reqKekKeyIdByteA), "error", err)
 				return nil, fmt.Errorf("error finding RSA key pair with id %X: %v", reqKekKeyIdByteA, err)
 			}
 
 			var privKey *hsm.AsymmetricDecryptionKey
 			if privKey, err = hsm.NewAsymmetricDecryptionKey(p.ctx, rsaKeyPair, reqKekKeyIdByteA, nil); err != nil {
-				logrus.WithError(err).Errorf("error creating AsymmetricDecryptionKey with id %X: %v", reqKekKeyIdByteA, err)
+				slog.Error("error creating AsymmetricDecryptionKey", "key_id", hex.EncodeToString(reqKekKeyIdByteA), "error", err)
 				return nil, fmt.Errorf("error creating AsymmetricDecryptionKey with id %X: %v", reqKekKeyIdByteA, err)
 			}
 			// create key store from private key
 			var store gose.AsymmetricDecryptionKeyStore
 			if store, err = gose.NewAsymmetricDecryptionKeyStoreImpl(map[string]gose.AsymmetricDecryptionKey{req.GetKeyId(): privKey}); err != nil {
-				logrus.WithError(err).Errorf("error creating AsymmetricDecryptionKeyStore with id %X: %v", reqKekKeyIdByteA, err)
+				slog.Error("error creating AsymmetricDecryptionKeyStore", "key_id", hex.EncodeToString(reqKekKeyIdByteA), "error", err)
 				return nil, fmt.Errorf("error creating AsymmetricDecryptionKeyStore with id %X: %v", reqKekKeyIdByteA, err)
 			}
 
@@ -742,11 +740,11 @@ func (p *P11) decryptWithContext(req *k8skmsv2.DecryptRequest, isRotation bool) 
 			// decrypt
 			out, _, err = decryptor.Decrypt(string(req.GetCiphertext()), crypto.SHA256)
 			if err != nil {
-				logrus.WithError(err).Error("decryption failed")
+				slog.Error("decryption failed", "error", err)
 				return nil, err
 			}
 		default:
-			logrus.Error("Decrypt: algorithm not supported")
+			slog.Error("Decrypt: algorithm not supported")
 		}
 	}
 	return out, nil
@@ -777,55 +775,47 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 		// Select algorithm
 		switch p.algorithm {
 		case jose.AlgA256GCM:
-			logrus.Tracef("p11:Encrypt case %s", jose.AlgA256GCM)
+			slog.Log(ctx, logging.LevelTrace, "p11 Encrypt case", "algorithm", string(jose.AlgA256GCM))
 			// Find the KEK in the KMS
 			var kek *crypto11.SecretKey
 			if kek, err = p.ctx.FindKey(p.kekCkaId, p.GetKekCkaLabelByteA()); nil != err {
-				logrus.WithError(err).WithFields(logrus.Fields{
-					"algorithm": jose.AlgA256GCM,
-					"label":     p.kekCkaLabel,
-					"keyId":     p.GetKekKeyIdString(),
-				}).Errorf("Encrypt: cannot find a symmetric key")
+				slog.Error("Encrypt: cannot find a symmetric key", "error", err, "algorithm", jose.AlgA256GCM, "label", p.kekCkaLabel, "key_id", p.GetKekKeyIdString())
 				return
 			}
 
 			// Random source from the HSM (pkcs11 context)
 			var rng io.Reader
 			if rng, err = p.ctx.NewRandomReader(); err != nil {
-				logrus.WithError(err).Errorf("Encrypt: cannot get a random source from the HSM (pkcs11 context)")
+				slog.Error("Encrypt: cannot get a random source from the HSM (pkcs11 context)", "error", err)
 				return
 			}
 			var aek gose.AeadEncryptionKey
 			// TODO investigate why the aek result does not have a kid
 			if aek, err = p.makeAeadKey(rng, kek); err != nil {
-				logrus.WithError(err).Errorf("Encrypt: cannot create an aead key")
+				slog.Error("Encrypt: cannot create an aead key", "error", err)
 				return
 			}
 
 			encryptor = gose.NewJweDirectEncryptorAead(aek, p.config.UseGCMIVFromHSM)
 			// output is the marshalled jwe
 			if out, err = encryptor.Encrypt(req.GetPlaintext(), nil); err != nil {
-				logrus.WithError(err).Error("Encrypt: encryption failed")
+				slog.Error("Encrypt: encryption failed", "error", err)
 				return
 			}
 
 		case jose.AlgA256CBC:
-			logrus.Tracef("p11:Encrypt case %s", jose.AlgA256CBC)
+			slog.Log(ctx, logging.LevelTrace, "p11 Encrypt case", "algorithm", string(jose.AlgA256CBC))
 			// Find the KEK in the KMS
 			var kek *crypto11.SecretKey
 			if kek, err = p.ctx.FindKey(p.kekCkaId, p.GetKekCkaLabelByteA()); nil != err {
-				logrus.WithError(err).WithFields(logrus.Fields{
-					"algorithm": p.algorithm,
-					"label":     p.kekCkaLabel,
-					"keyId":     p.GetKekKeyIdString(),
-				}).Errorf("Encrypt: cannot find a symmetric key")
+				slog.Error("Encrypt: cannot find a symmetric key", "error", err, "algorithm", p.algorithm, "label", p.kekCkaLabel, "key_id", p.GetKekKeyIdString())
 				return
 			}
 
 			// Random source from the HSM (pkcs11 context)
 			var rng io.Reader
 			if rng, err = p.ctx.NewRandomReader(); err != nil {
-				logrus.WithError(err).Errorf("Encrypt: cannot get a random source from the HSM (pkcs11 context)")
+				slog.Error("Encrypt: cannot get a random source from the HSM (pkcs11 context)", "error", err)
 				return
 			}
 			// generate the IV from the KMS, using the kek block size
@@ -856,12 +846,12 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 			defer blockMode.Close()
 			// output is the marshalled jwe
 			if out, err = encryptor.Encrypt(req.GetPlaintext(), nil); err != nil {
-				logrus.WithError(err).Error("Encrypt: encryption failed")
+				slog.Error("Encrypt: encryption failed", "error", err)
 				return
 			}
 
 		case jose.AlgRSAOAEP:
-			logrus.Tracef("p11:Encrypt case %s", jose.AlgRSAOAEP)
+			slog.Log(ctx, logging.LevelTrace, "p11 Encrypt case", "algorithm", string(jose.AlgRSAOAEP))
 			//TODO generate a jwk with the kid of the public key. Ex :
 			//      {"kty":"EC",
 			//         "crv":"P-256",
@@ -882,11 +872,7 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 			//    }
 			var rsaKeyPair crypto11.SignerDecrypter
 			if rsaKeyPair, err = p.ctx.FindRSAKeyPair(p.kekCkaId, p.GetKekCkaLabelByteA()); err != nil {
-				logrus.WithError(err).WithFields(logrus.Fields{
-					"algorithm": p.algorithm,
-					"label":     p.kekCkaLabel,
-					"keyId":     p.GetKekKeyIdString(),
-				}).Errorf("Encrypt: cannot find an rsa key pair with label %s", p.kekCkaLabel)
+				slog.Error("Encrypt: cannot find an RSA key pair", "error", err, "algorithm", p.algorithm, "label", p.kekCkaLabel, "key_id", p.GetKekKeyIdString())
 				return nil, err
 			}
 
@@ -897,7 +883,7 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 			// generate jwk from public key
 			var pubJwk jose.Jwk
 			if pubJwk, err = gose.JwkFromPublicKey(pubkey, []jose.KeyOps{jose.KeyOpsEncrypt}, nil); err != nil {
-				logrus.WithError(err).Error("Failed to create JWE RSA Key Encryption Encryptor")
+				slog.Error("Failed to create JWE RSA Key Encryption Encryptor", "error", err)
 				return nil, err
 			}
 			// set JWK Algorithm for encryption
@@ -906,16 +892,16 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 			// encrypt plaintext
 			var rsaEncryptor *gose.JweRsaKeyEncryptionEncryptorImpl
 			if rsaEncryptor, err = gose.NewJweRsaKeyEncryptionEncryptorImpl(pubJwk, rand.Reader); err != nil {
-				logrus.WithError(err).Error("Failed to create JWE RSA Key Encryption Encryptor")
+				slog.Error("Failed to create JWE RSA Key Encryption Encryptor", "error", err)
 				return nil, err
 			}
 			// output is the marshalled jwe
 			if out, err = rsaEncryptor.Encrypt(req.GetPlaintext(), crypto.SHA256); err != nil {
-				logrus.WithError(err).Error("Encrypt: encryption failed")
+				slog.Error("Encrypt: encryption failed", "error", err)
 				return
 			}
 		default:
-			logrus.Infof("Encrypt: not supported algorithm: %s", p.algorithm)
+			slog.Error("Encrypt: unsupported algorithm", "algorithm", p.algorithm)
 		}
 	}
 
@@ -931,29 +917,29 @@ func (s *P11) UnaryInterceptor(ctx context.Context, req interface{}, info *grpc.
 	switch req.(type) {
 	case *k8skmsv2.StatusRequest:
 		{
-			logrus.Trace("UnaryInterceptor kms v2 StatusRequest")
+			slog.Log(ctx, logging.LevelTrace, "UnaryInterceptor kms v2 StatusRequest")
 		}
 	case *k8skmsv2.EncryptRequest:
 		{
-			logrus.Trace("UnaryInterceptor kms v2 EncryptRequest")
+			slog.Log(ctx, logging.LevelTrace, "UnaryInterceptor kms v2 EncryptRequest")
 		}
 	case *k8skmsv2.DecryptRequest:
 		{
-			logrus.Trace("UnaryInterceptor kms v2 DecryptRequest")
+			slog.Log(ctx, logging.LevelTrace, "UnaryInterceptor kms v2 DecryptRequest")
 			if (req).(*k8skmsv2.DecryptRequest).GetKeyId() == "" {
-				logrus.Error("UnaryInterceptor: KeyId is empty in the DecryptRequest")
+				slog.Error("UnaryInterceptor: KeyId is empty in the DecryptRequest")
 				return nil, status.Errorf(codes.InvalidArgument, "UnaryInterceptor: KeyId is empty in the DecryptRequest")
 			}
 		}
 	default:
 		{
-			logrus.Trace("UnaryInterceptor default")
+			slog.Log(ctx, logging.LevelTrace, "UnaryInterceptor default")
 		}
 	}
 
 	resp, err = handler(ctx, req)
 	if err != nil {
-		logrus.Error(err)
+		slog.Error("handler error", "error", err)
 	}
 	return resp, err
 }
@@ -966,18 +952,18 @@ func (s *P11) UnaryInterceptor(ctx context.Context, req interface{}, info *grpc.
 // Also check the content of a StatusResponse
 // See https://pkg.go.dev/k8s.io/kms@v0.31.3/apis/v2#StatusResponse
 func (p *P11) Status(ctx context.Context, request *k8skmsv2.StatusRequest) (statusResponse *k8skmsv2.StatusResponse, err error) {
-	logrus.Trace("p11 Status: entering method")
+	slog.Log(ctx, logging.LevelTrace, "p11 Status: entering method")
 
 	// NewP11 should populate both KEK ID (CKA_ID) and Key label (CKA_LABEL), but check the content just in case.
 	if p.kekCkaId == nil {
 		err = errors.New("KEK ID is nil")
-		logrus.WithError(err).Error("p11 Status: error due to missing KEK ID")
+		slog.Error("p11 Status: error due to missing KEK ID", "error", err)
 		return
 	}
 
 	if len(p.kekCkaId) == 0 {
 		err = errors.New("KEK ID is empty")
-		logrus.WithError(err).Error("p11 Status: error due to missing KEK ID")
+		slog.Error("p11 Status: error due to missing KEK ID", "error", err)
 		return
 	}
 
@@ -987,11 +973,7 @@ func (p *P11) Status(ctx context.Context, request *k8skmsv2.StatusRequest) (stat
 		KeyId:   p.GetKekKeyIdString(),
 	}
 
-	logrus.WithFields(logrus.Fields{
-		"Version": statusResponse.Version,
-		"Healthz": statusResponse.Healthz,
-		"KeyId":   statusResponse.KeyId,
-	}).Debug("StatusResponse")
+	slog.Debug("status response", "version", statusResponse.Version, "healthz", statusResponse.Healthz, "key_id", statusResponse.KeyId)
 	return statusResponse, nil
 }
 
@@ -1033,14 +1015,14 @@ func FindCkaAttrByIdOrLabel(ctx *crypto11.Context, algorithm jose.Alg, ckaAttr c
 			// Find the key in the KMS for AES symmetric algorithms
 			var symKey *crypto11.SecretKey
 			if symKey, err = ctx.FindKey(id, label); nil != err {
-				logrus.WithError(err).Errorf("FindCkaAttrByIdOrLabel:cannot find a %s symmetric key with label %x or id %x", algorithm, label, id)
+				slog.Error("FindCkaAttrByIdOrLabel: cannot find symmetric key", "algorithm", algorithm, "label", hex.EncodeToString(label), "key_id", hex.EncodeToString(id), "error", err)
 				return nil, err
 			}
 
 			// Get the CKA_ID to obtain the KEK key id
 			var attr *crypto11.Attribute
 			if attr, err = ctx.GetAttribute(symKey, ckaAttr); err != nil {
-				logrus.WithError(err).Errorf("FindCkaAttrByIdOrLabel: cannot get the CKA_ attribute %v for algo %s and key with label %x or id %x", ckaAttr, algorithm, label, id)
+				slog.Error("FindCkaAttrByIdOrLabel: cannot get attribute", "attr", ckaAttr, "algorithm", algorithm, "label", hex.EncodeToString(label), "key_id", hex.EncodeToString(id), "error", err)
 				return nil, err
 			} else {
 				outBuf = attr.Value
@@ -1049,21 +1031,21 @@ func FindCkaAttrByIdOrLabel(ctx *crypto11.Context, algorithm jose.Alg, ckaAttr c
 			// Find the key in the KMS for RSA asymmetric algorithms
 			var rsaKeyPair crypto11.SignerDecrypter
 			if rsaKeyPair, err = ctx.FindRSAKeyPair(id, label); err != nil {
-				logrus.WithError(err).Errorf("FindCkaAttrByIdOrLabel: cannot find an rsa key pair with label %x or id %x", label, id)
+				slog.Error("FindCkaAttrByIdOrLabel: cannot find RSA key pair", "label", hex.EncodeToString(label), "key_id", hex.EncodeToString(id), "error", err)
 				return nil, err
 			}
 
 			// Get the key id by key label
 			var attr *crypto11.Attribute
 			if attr, err = ctx.GetAttribute(rsaKeyPair, ckaAttr); err != nil {
-				logrus.WithError(err).Errorf("FindCkaAttrByIdOrLabel: cannot get the CKA_ attribute %v for algo %s and with label %x or id %x", ckaAttr, algorithm, label, id)
+				slog.Error("FindCkaAttrByIdOrLabel: cannot get attribute", "attr", ckaAttr, "algorithm", algorithm, "label", hex.EncodeToString(label), "key_id", hex.EncodeToString(id), "error", err)
 				return nil, err
 			} else {
 				outBuf = attr.Value
 			}
 		}
 	} else {
-		logrus.Errorf("FindCkaAttrByIdOrLabel: cannot find a key with parameters id%x and label%x", id, label)
+		slog.Error("FindCkaAttrByIdOrLabel: invalid parameters", "key_id", hex.EncodeToString(id), "label", hex.EncodeToString(label))
 		return nil, fmt.Errorf("FindCkaAttrByIdOrLabel: cannot find a key with parameters id%x and label%x", id, label)
 	}
 
@@ -1081,19 +1063,19 @@ func FindCkaAttrByIdOrLabel(ctx *crypto11.Context, algorithm jose.Alg, ckaAttr c
 func GetKeyIdAndLabel(p *P11, keyId string, keyLabel string) (resultKeyId []byte, resultKeyLabel string, err error) {
 	var resultKeyLabelBytes []byte
 	if keyId == "" && keyLabel != "" {
-		logrus.Tracef("NewP11: key id (CKA_ID) is empty. Find CKA_ID by CKA_LABEL %s", keyLabel)
+		slog.Log(context.Background(), logging.LevelTrace, "NewP11: finding CKA_ID by CKA_LABEL", "key_label", keyLabel)
 		resultKeyLabel = keyLabel
 
 		keyLabelBytes := []byte(keyLabel)
 		resultKeyId, err = FindCkaAttrByIdOrLabel(p.ctx, p.algorithm, crypto11.CkaId, nil, keyLabelBytes)
 		if err != nil {
-			logrus.WithError(err).Errorf("NewP11: failed to find key CKA_ID by CKA_LABEL '%s'", resultKeyLabel)
+			slog.Error("NewP11: failed to find key CKA_ID by CKA_LABEL", "key_label", resultKeyLabel, "error", err)
 			return nil, "", err
 		}
 
-		// panic error if the CKA_ID if the key, found using its label, is empty.
+		// exit with fatal error if the CKA_ID of the key, found using its label, is empty.
 		if len(resultKeyId) == 0 {
-			logrus.Fatalf("NewP11: Fatal error : key ID (CKA_ID) empty for key label (CKA_LABEL) '%s'. k8s-kms-plugin only supports keys with a CKA_ID in HSM", keyLabel)
+			logging.Fatal("NewP11: key CKA_ID is empty; only keys with a CKA_ID are supported", "key_label", keyLabel)
 		}
 	} else if keyId != "" && keyLabel == "" {
 		// Case: KEK ID already provided by user at startup with flag --p11-key-id
@@ -1102,25 +1084,25 @@ func GetKeyIdAndLabel(p *P11, keyId string, keyLabel string) (resultKeyId []byte
 		// API calls.
 		// But we could use EncryptResponse.Annotations and DecryptRequest.Annotations to store
 		// the value of the key label CKA_LABEL.
-		logrus.Tracef("NewP11: key label (CKA_LABEL) is empty but key id (CKA_ID) is not empty. Find CKA_LABEL by CKA_ID %s", keyId)
+		slog.Log(context.Background(), logging.LevelTrace, "NewP11: finding CKA_LABEL by CKA_ID", "key_id", keyId)
 		resultKeyId, err = hex.DecodeString(keyId)
 		if err != nil {
 			return nil, "", fmt.Errorf("NewP11: cannot decode string CKA_ID into hex expected format '%s': %w", keyId, err)
 		}
 
 		if resultKeyLabelBytes, err = FindCkaAttrByIdOrLabel(p.ctx, p.algorithm, crypto11.CkaLabel, resultKeyId, nil); err != nil {
-			logrus.WithError(err).Error("NewP11: failed to find key CKA_LABEL by CKA_ID '%s'", resultKeyId)
+			slog.Error("NewP11: failed to find key CKA_LABEL by CKA_ID", "key_id", hex.EncodeToString(resultKeyId), "error", err)
 			return nil, "", err
 		}
 		resultKeyLabel = string(resultKeyLabelBytes)
 	} else if keyId == "" && keyLabel == "" {
-		errMsg := "NewP11: key ID (CKA_ID) and key label (CKA_LABEL) are both empty, please provide one of them"
-		logrus.WithError(err).Errorf(errMsg)
-		return nil, "", fmt.Errorf(errMsg)
+		err = errors.New("NewP11: key ID (CKA_ID) and key label (CKA_LABEL) are both empty, please provide one of them")
+		slog.Error("NewP11: missing key identifier", "error", err)
+		return nil, "", err
 	} else {
-		errMsg := "NewP11: both key ID (CKA_ID) and key label (CKA_LABEL) are provided, please provide only one"
-		logrus.WithError(err).Errorf(errMsg)
-		return nil, "", fmt.Errorf(errMsg)
+		err = errors.New("NewP11: both key ID (CKA_ID) and key label (CKA_LABEL) are provided, please provide only one")
+		slog.Error("NewP11: conflicting key identifiers", "error", err)
+		return nil, "", err
 	}
 
 	return

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 
 	go_version "github.com/hashicorp/go-version"
-	"github.com/sirupsen/logrus"
+	"log/slog"
 	"gopkg.in/yaml.v2"
 )
 
@@ -66,7 +66,7 @@ func IsDirty(isDirtyStr string) (bool, error) {
 	case "false":
 		return false, nil
 	default:
-		logrus.WithField("GitDirtyStr", isDirtyStr).Warn("Unexpected Git dirty string, assuming clean")
+		slog.Warn("Unexpected Git dirty string, assuming clean", "GitDirtyStr", isDirtyStr)
 		return false, fmt.Errorf("invalid dirty information: %s", GitDirtyStr)
 	}
 }
@@ -88,17 +88,14 @@ func NewVersionData() (VersionData, error) {
 	isDirty, err := IsDirty(GitDirtyStr)
 	if err != nil {
 		// only do a warning, do not return an error
-		logrus.WithError(err).Warning("Failed to parse Git dirty status")
+		slog.Warn("Failed to parse Git dirty status", "error", err)
 	}
 	versionData.IsGitDirty = isDirty
 
 	// Check if RawGitDescribe is a valid semantic version or a commit hash
 	version, err := go_version.NewSemver(RawGitDescribe)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"raw_git_describe": RawGitDescribe,
-			"error":            err,
-		}).Debug("Invalid semantic versioning, falling back to snapshot version")
+		slog.Debug("Invalid semantic versioning, falling back to snapshot version", "raw_git_describe", RawGitDescribe, "error", err)
 		return versionData, nil
 	}
 
@@ -150,30 +147,30 @@ func returnYamlVersion() ([]byte, error) {
 
 	yamlData, err := yaml.Marshal(versionDetails)
 	if err != nil {
-		logrus.WithError(err).Error("Failed to marshal YAML")
+		slog.Error("Failed to marshal YAML", "error", err)
 		return nil, err
 	}
 	return yamlData, nil
 }
 
-// LogrusOutputVersion logs the version details at server startup. For server logging.
-func LogrusOutputVersion() {
+// LogVersion logs the version details at server startup.
+func LogVersion() {
 	versionData, err := NewVersionData()
 	if err != nil {
-		logrus.WithError(err).Error("Failed to fetch version data")
+		slog.Error("Failed to fetch version data", "error", err)
 		return
 	}
 
-	logrus.Infof("k8s-kms-plugin version: %s", versionData.Version)
-	logrus.WithFields(logrus.Fields{
-		"build-date":       versionData.BuildDate,
-		"build-platform":   versionData.BuildPlatform,
-		"commit":           versionData.GitCommitIdLong,
-		"go-version":       versionData.GoVersion,
-		"raw-git-describe": versionData.Version,
-		"is-git-dirty":     versionData.IsGitDirty,
-		"short-commit":     versionData.GitCommitIdShort,
-	}).Debug("k8s-kms-plugin version details")
+	slog.Info(fmt.Sprintf("k8s-kms-plugin version: %s", versionData.Version))
+	slog.Debug("k8s-kms-plugin version details",
+		"build-date", versionData.BuildDate,
+		"build-platform", versionData.BuildPlatform,
+		"commit", versionData.GitCommitIdLong,
+		"go-version", versionData.GoVersion,
+		"raw-git-describe", versionData.Version,
+		"is-git-dirty", versionData.IsGitDirty,
+		"short-commit", versionData.GitCommitIdShort,
+	)
 }
 
 // VersionOutputToString returns the version as a formatted string.
@@ -182,21 +179,21 @@ func VersionOutputToString(outputFormat string, prettyPrint bool) string {
 	case "json":
 		data, err := returnJsonVersion(prettyPrint)
 		if err != nil {
-			logrus.WithError(err).Error("Failed to generate JSON version output")
+			slog.Error("Failed to generate JSON version output", "error", err)
 			return "Error generating JSON output"
 		}
 		return string(data)
 	case "yaml":
 		data, err := returnYamlVersion()
 		if err != nil {
-			logrus.WithError(err).Error("Failed to generate YAML version output")
+			slog.Error("Failed to generate YAML version output", "error", err)
 			return "Error generating YAML output"
 		}
 		return string(data)
 	default:
 		version, err := go_version.NewSemver(RawGitDescribe)
 		if err != nil {
-			logrus.WithError(err).Debug("Invalid semantic versioning, falling back to snapshot version")
+			slog.Debug("Invalid semantic versioning, falling back to snapshot version", "error", err)
 			return fmt.Sprintf("k8s-kms-plugin: (snapshot) %s", RawGitDescribe)
 		}
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -11,10 +11,11 @@ package version
 
 import (
 	"encoding/json"
+	"io"
+	"log/slog"
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -337,6 +338,6 @@ func TestIsPopulated(t *testing.T) {
 }
 
 func init() {
-	// Disable logrus output for testing purposes
-	logrus.SetOutput(logrus.New().Writer())
+	// Discard slog output during tests
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 }

--- a/test/integration/p11_integration_test.go
+++ b/test/integration/p11_integration_test.go
@@ -28,9 +28,10 @@ import (
 	"github.com/ThalesGroup/gose/jose"
 	"github.com/ThalesGroup/k8s-kms-plugin/pkg/providers"
 
+	"log/slog"
+
 	"github.com/google/uuid"
 	"github.com/miekg/pkcs11"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	k8skmsv2 "k8s.io/kms/apis/v2"
@@ -285,7 +286,7 @@ func setupTpm2Pkcs11TestCase(t testing.TB) {
 
 	att, err := testCtx.GetAttribute(secretKey, crypto11.CkaId)
 	if err != nil {
-		logrus.WithError(err).Errorf("setupTpm2Pkcs11TestCase: cannot get the CKA_ID attribute for the secret key %v", secretKeyLabel)
+		slog.Error("setupTpm2Pkcs11TestCase: cannot get the CKA_ID attribute for the secret key", "key", secretKeyLabel, "error", err)
 		return
 	}
 	testKid = att.Value


### PR DESCRIPTION
* replace logrus with log/slog across all packages

Migrate all logging calls from github.com/sirupsen/logrus to the standard library log/slog (Go 1.21+). Key changes:

- Add pkg/logging package with LevelTrace = slog.Level(-8) constant and ParseLevel helper shared across cmd and provider packages
- Add github.com/lmittmann/tint for colored text handler (replaces logrus text formatter with color support)
- Replace logrus-filename hook with slog.HandlerOptions{AddSource: true}
- Rename version.LogrusOutputVersion() to version.LogVersion()
- Accept log levels: trace, debug, info, warn, error, quiet (drop logrus-specific: warning, fatal, panic)
- logrus.Fatal → slog.Error + os.Exit(1)
- logrus.Trace/Tracef → slog.Log(ctx, logging.LevelTrace, ...)
- logrus.WithFields/WithField/WithError → inline slog key-value pairs
- Remove github.com/keepeye/logrus-filename from go.mod
- logrus remains only as an indirect dependency (pulled by other modules)

https://claude.ai/code/session_01BDmDyCyMiNjx4HMQwPWv7s

* Improve slog usage: structured args, snake_case keys, Fatal helper, LevelVar

- Add logging.Fatal helper (slog.Error + os.Exit(1)) to pkg/logging
- Add activeLogLevel (*slog.LevelVar) in root.go for runtime-adjustable level
- Replace all fmt.Sprintf inside slog calls with structured key-value args
- Fix slog.Error(err.Error()) anti-pattern throughout; pass err as "error" attr
- Fix nil-panic bug in istio.go GenerateDEK (err was nil when request==nil)
- Rename all log keys to snake_case: cobra-cmd→cobra_cmd, keyId→key_id, etc.
- Use real gRPC ctx instead of context.Background() in Encrypt method traces
- Replace slog.Error+os.Exit(1) patterns with logging.Fatal in serve/rotation/test
- Drop unused fmt and os imports where no longer needed

https://claude.ai/code/session_01BDmDyCyMiNjx4HMQwPWv7s

* Update copyright year to 2026 in modified files

https://claude.ai/code/session_01BDmDyCyMiNjx4HMQwPWv7s

* logging: add quiet level that discards all output

Introduce logging.LevelQuiet (slog.Level(math.MaxInt)) and wire it up so that --log-level=quiet installs slog.DiscardHandler, producing no log output at all.

- pkg/logging: add LevelQuiet constant, "quiet" case in ParseLevel
- cmd/root.go: detect LevelQuiet in initConfig and short-circuit with slog.DiscardHandler; update --log-level flag description and shell completion to include "quiet"

https://claude.ai/code/session_01BDmDyCyMiNjx4HMQwPWv7s

---------

<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

#### Types of Changes ####

<!-- What types of changes does your code introduce ? Bugfix, New Feature, Breaking Change, etc -->

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first. A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

https://github.com/ThalesGroup/k8s-kms-plugin/issues/48

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Further Comments ####

gose and crypto11 will soon replace logrus by log/slog.
